### PR TITLE
fix: handle the case when the gateway suffix (in HA mode) ends up being a number

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -328,4 +328,10 @@ func Test_Misc(t *testing.T) {
 
 	t.Setenv("INSTANCE_ID", "prousmtusmt-v0-rs")
 	require.Equal(t, "", GetInstanceID())
+
+	t.Setenv("INSTANCE_ID", "prousmtusmt-v0-rs-gw-10")
+	require.Equal(t, "10", GetInstanceID())
+
+	t.Setenv("INSTANCE_ID", "prousmtusmt-v0-rs-gw-ha-12-234234-10")
+	require.Equal(t, "12", GetInstanceID())
 }

--- a/config/misc.go
+++ b/config/misc.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+var (
+	regexGwHa               = regexp.MustCompile(`^.*-gw-ha-\d+-\w+-\w+$`)
+	regexGwNonHaOrProcessor = regexp.MustCompile(`^.*-\d+$`)
+)
+
 // GetWorkspaceToken returns the workspace token provided in the environment variables
 // Env variable CONFIG_BACKEND_TOKEN is deprecating soon
 // WORKSPACE_TOKEN is newly introduced. This will override CONFIG_BACKEND_TOKEN
@@ -35,8 +40,6 @@ func GetInstanceID() string {
 	instance := GetString("INSTANCE_ID", "")
 	instanceArr := strings.Split(instance, "-")
 	length := len(instanceArr)
-	regexGwHa := regexp.MustCompile(`^.*-gw-ha-\d+-\w+-\w+$`)
-	regexGwNonHaOrProcessor := regexp.MustCompile(`^.*-\d+$`)
 	// This handles 2 kinds of server instances
 	// a) Processor OR Gateway running in non HA mod where the instance name ends with the index
 	// b) Gateway running in HA mode, where the instance name is of the form *-gw-ha-<index>-<statefulset-id>-<pod-id>


### PR DESCRIPTION
# Description

To get the instance id of the pod, we were first checking that the last token (split by -) is an integer or not, in which case we returned that. If not, we used the third to last token (to handle the case for gw ha pods) to get  the index. However, this breaks down if the ha pods end up receiving a suffix which is an integer. This change fixes that issue. 
