### PR TITLE
chore: remove get instance id function

### DIFF
--- a/config/misc.go
+++ b/config/misc.go
@@ -3,7 +3,6 @@ package config
 import (
 	"os"
 	"regexp"
-	"strings"
 )
 
 var (
@@ -34,21 +33,6 @@ func GetNamespaceIdentifier() string {
 // GetKubeNamespace returns value stored in KUBE_NAMESPACE env var
 func GetKubeNamespace() string {
 	return os.Getenv("KUBE_NAMESPACE")
-}
-
-func GetInstanceID() string {
-	instance := GetString("INSTANCE_ID", "")
-	instanceArr := strings.Split(instance, "-")
-	length := len(instanceArr)
-	// This handles 2 kinds of server instances
-	// a) Processor OR Gateway running in non HA mod where the instance name ends with the index
-	// b) Gateway running in HA mode, where the instance name is of the form *-gw-ha-<index>-<statefulset-id>-<pod-id>
-	if (regexGwHa.MatchString(instance)) && (length > 3) {
-		return instanceArr[length-3]
-	} else if (regexGwNonHaOrProcessor.MatchString(instance)) && (length > 1) {
-		return instanceArr[length-1]
-	}
-	return ""
 }
 
 func GetReleaseName() string {


### PR DESCRIPTION
# Description

Removing the rudder server specific getInstanceID function from go-kit

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/jobsdb-forwarder-30d8716a0f484f2b91254be1671751b3)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
