### PR TITLE
fix: race condition for err variable when statsd start is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.html
 *.orig
 **/gomock_reflect_*/*
 ginkgo.report
+vendor/

--- a/stats/statsd.go
+++ b/stats/statsd.go
@@ -24,7 +24,7 @@ type statsdStats struct {
 	backgroundCollectionCancel func()
 }
 
-func (s *statsdStats) Start(ctx context.Context, goFactory GoRoutineFactory) (err error) {
+func (s *statsdStats) Start(ctx context.Context, goFactory GoRoutineFactory) error {
 	if !s.config.enabled.Load() {
 		return nil
 	}
@@ -34,6 +34,7 @@ func (s *statsdStats) Start(ctx context.Context, goFactory GoRoutineFactory) (er
 
 	// NOTE: this is to get at least a dummy client, even if there is a failure.
 	// So, that nil pointer error is not received when client is called.
+	var err error
 	s.state.client.statsd, err = statsd.New(s.state.conn, s.statsdConfig.statsdTagsFormat(), s.statsdConfig.statsdDefaultTags())
 	if err == nil {
 		s.logger.Info("StatsD client setup succeeded.")


### PR DESCRIPTION
# Description
Before this change, the error variable declared in the start function syntax is modified by the goroutine at line 48. Since we are returning nil at the end, err variable is set to nil. leading to a potential data race by main routine and go routine
Test this in [go playground](https://go.dev/play/p/L2u7NfBpQCb)
I got to know about it when I was testing this [pr](https://github.com/rudderlabs/rudder-sources/pull/929) for a race condition.
These are the logs, i got when i ran rudder-sources in race condition
```
==================
WARNING: DATA RACE
Write at 0x00c0004884f0 by main goroutine:
  github.com/rudderlabs/rudder-go-kit/stats.(*statsdStats).Start()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/vendor/github.com/rudderlabs/rudder-go-kit/stats/statsd.go:69 +0x5b8
  github.com/rudderlabs/rudder-sources/metrics/stats.Setup()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/metrics/stats/stats.go:27 +0x254
  github.com/rudderlabs/rudder-sources/app.(*App).initMetrics()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/app/app.go:136 +0x6c
  github.com/rudderlabs/rudder-sources/app.New()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/app/app.go:48 +0x240
  main.main()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/cmd/rudder-sources/main.go:143 +0xdec

Previous read at 0x00c0004884f0 by goroutine 32:
  github.com/rudderlabs/rudder-go-kit/stats.(*statsdStats).Start.func1()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/vendor/github.com/rudderlabs/rudder-go-kit/stats/statsd.go:45 +0x5c

Goroutine 32 (running) created at:
  github.com/rudderlabs/rudder-go-kit/stats.defaultGoRoutineFactory.Go()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/vendor/github.com/rudderlabs/rudder-go-kit/stats/stats.go:141 +0x28
  github.com/rudderlabs/rudder-go-kit/stats.(*defaultGoRoutineFactory).Go()
      <autogenerated>:1 +0x3c
  github.com/rudderlabs/rudder-go-kit/stats.(*statsdStats).Start()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/vendor/github.com/rudderlabs/rudder-go-kit/stats/statsd.go:44 +0x4b0
  github.com/rudderlabs/rudder-sources/metrics/stats.Setup()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/metrics/stats/stats.go:27 +0x254
  github.com/rudderlabs/rudder-sources/app.(*App).initMetrics()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/app/app.go:136 +0x6c
  github.com/rudderlabs/rudder-sources/app.New()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/app/app.go:48 +0x240
  main.main()
      /Users/ganeshvarmaraghavaraju/rudderstack/rudder-sources/cmd/rudder-sources/main.go:143 +0xdec
==================
```

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
