### PR TITLE
fix: instanceName consistency

### DIFF
--- a/stats/internal/otel/otel.go
+++ b/stats/internal/otel/otel.go
@@ -208,11 +208,10 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 
 // NewResource allows the creation of an OpenTelemetry resource
 // https://opentelemetry.io/docs/concepts/glossary/#resource
-func NewResource(svcName, instanceID, svcVersion string, attrs ...attribute.KeyValue) (*resource.Resource, error) {
+func NewResource(svcName, svcVersion string, attrs ...attribute.KeyValue) (*resource.Resource, error) {
 	defaultAttrs := []attribute.KeyValue{
 		semconv.ServiceNameKey.String(svcName),
 		semconv.ServiceVersionKey.String(svcVersion),
-		semconv.ServiceInstanceIDKey.String(instanceID),
 	}
 	return resource.Merge(
 		resource.Default(),

--- a/stats/internal/otel/otel_test.go
+++ b/stats/internal/otel/otel_test.go
@@ -3,12 +3,6 @@ package otel
 import (
 	"context"
 	"fmt"
-	"github.com/ory/dockertest/v3"
-	"github.com/ory/dockertest/v3/docker"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/metric/global"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -18,9 +12,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	promClient "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/global"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 
 	"github.com/rudderlabs/rudder-go-kit/httputil"

--- a/stats/internal/otel/prometheus/config.go
+++ b/stats/internal/otel/prometheus/config.go
@@ -16,7 +16,6 @@ type config struct {
 	disableTargetInfo bool
 	withoutUnits      bool
 	aggregation       metric.AggregationSelector
-	disableScopeInfo  bool
 	logger            logger
 }
 
@@ -98,16 +97,6 @@ func WithoutTargetInfo() Option {
 func WithoutUnits() Option {
 	return optionFunc(func(cfg config) config {
 		cfg.withoutUnits = true
-		return cfg
-	})
-}
-
-// WithoutScopeInfo configures the Exporter to not export the otel_scope_info metric.
-// If not specified, the Exporter will create a otel_scope_info metric containing
-// the metrics' Instrumentation Scope, and also add labels about Instrumentation Scope to all metric points.
-func WithoutScopeInfo() Option {
-	return optionFunc(func(cfg config) config {
-		cfg.disableScopeInfo = true
 		return cfg
 	})
 }

--- a/stats/internal/otel/prometheus/exporter.go
+++ b/stats/internal/otel/prometheus/exporter.go
@@ -13,6 +13,8 @@
 //
 //  3. a global logger was used, we made it injectable via options
 //     see here: https://github.com/open-telemetry/opentelemetry-go/blob/v1.14.0/exporters/prometheus/exporter.go#L393
+//
+//  4. removed unnecessary otel_scope_info metric
 package prometheus
 
 import (
@@ -41,24 +43,6 @@ import (
 const (
 	targetInfoMetricName  = "target_info"
 	targetInfoDescription = "Target metadata"
-
-	scopeInfoMetricName  = "otel_scope_info"
-	scopeInfoDescription = "Instrumentation Scope metadata"
-)
-
-var (
-	scopeInfoKeys = [2]string{
-		string(semconv.ServiceNameKey),
-		string(semconv.ServiceInstanceIDKey),
-	}
-	scopeInfoKeysMapping = map[string]string{
-		string(semconv.ServiceNameKey):       "job",
-		string(semconv.ServiceInstanceIDKey): "instanceName",
-	}
-	scopeInfoKeysRenamed = [2]string{
-		scopeInfoKeysMapping[scopeInfoKeys[0]],
-		scopeInfoKeysMapping[scopeInfoKeys[1]],
-	}
 )
 
 // Exporter is a Prometheus Exporter that embeds the OTel metric.Reader
@@ -77,7 +61,6 @@ type collector struct {
 	disableTargetInfo    bool
 	withoutUnits         bool
 	targetInfo           prometheus.Metric
-	disableScopeInfo     bool
 	createTargetInfoOnce sync.Once
 	scopeInfos           map[instrumentation.Scope]prometheus.Metric
 	metricFamilies       map[string]*dto.MetricFamily
@@ -96,7 +79,6 @@ func New(opts ...Option) (*Exporter, error) {
 		logger:            cfg.logger,
 		disableTargetInfo: cfg.disableTargetInfo,
 		withoutUnits:      cfg.withoutUnits,
-		disableScopeInfo:  cfg.disableScopeInfo,
 		scopeInfos:        make(map[instrumentation.Scope]prometheus.Metric),
 		metricFamilies:    make(map[string]*dto.MetricFamily),
 	}
@@ -140,37 +122,29 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		ch <- c.targetInfo
 	}
 
-	scopeInfoValues := getScopeInfoValues(metrics.Resource, scopeInfoKeys[:])
+	var scopeKeys, scopeValues []string
+	for _, attr := range metrics.Resource.Attributes() {
+		if string(attr.Key) == string(semconv.ServiceNameKey) {
+			scopeKeys = append(scopeKeys, "job")
+			scopeValues = append(scopeValues, attr.Value.AsString())
+		}
+		scopeKeys = append(scopeKeys, strings.ReplaceAll(string(attr.Key), ".", "_"))
+		scopeValues = append(scopeValues, attr.Value.AsString())
+	}
 
 	for _, scopeMetrics := range metrics.ScopeMetrics {
-		var keys, values [2]string
-
-		if !c.disableScopeInfo {
-			scopeInfo, ok := c.scopeInfos[scopeMetrics.Scope]
-			if !ok {
-				scopeInfo, err = createScopeInfoMetric(scopeMetrics.Scope)
-				if err != nil {
-					otel.Handle(err)
-				}
-				c.scopeInfos[scopeMetrics.Scope] = scopeInfo
-			}
-			ch <- scopeInfo
-			keys = scopeInfoKeysRenamed
-			values = [2]string{scopeInfoValues[0], scopeInfoValues[1]}
-		}
-
 		for _, m := range scopeMetrics.Metrics {
 			switch v := m.Data.(type) {
 			case metricdata.Histogram:
-				addHistogramMetric(ch, v, m, keys, values, c.getName(m), c.metricFamilies, c.logger)
+				addHistogramMetric(ch, v, m, scopeKeys, scopeValues, c.getName(m), c.metricFamilies, c.logger)
 			case metricdata.Sum[int64]:
-				addSumMetric(ch, v, m, keys, values, c.getName(m), c.metricFamilies, c.logger)
+				addSumMetric(ch, v, m, scopeKeys, scopeValues, c.getName(m), c.metricFamilies, c.logger)
 			case metricdata.Sum[float64]:
-				addSumMetric(ch, v, m, keys, values, c.getName(m), c.metricFamilies, c.logger)
+				addSumMetric(ch, v, m, scopeKeys, scopeValues, c.getName(m), c.metricFamilies, c.logger)
 			case metricdata.Gauge[int64]:
-				addGaugeMetric(ch, v, m, keys, values, c.getName(m), c.metricFamilies, c.logger)
+				addGaugeMetric(ch, v, m, scopeKeys, scopeValues, c.getName(m), c.metricFamilies, c.logger)
 			case metricdata.Gauge[float64]:
-				addGaugeMetric(ch, v, m, keys, values, c.getName(m), c.metricFamilies, c.logger)
+				addGaugeMetric(ch, v, m, scopeKeys, scopeValues, c.getName(m), c.metricFamilies, c.logger)
 			}
 		}
 	}
@@ -178,7 +152,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 
 func addHistogramMetric(
 	ch chan<- prometheus.Metric, histogram metricdata.Histogram, m metricdata.Metrics,
-	ks, vs [2]string, name string, mfs map[string]*dto.MetricFamily, l logger,
+	ks, vs []string, name string, mfs map[string]*dto.MetricFamily, l logger,
 ) {
 	drop, help := validateMetrics(name, m.Description, dto.MetricType_HISTOGRAM.Enum(), mfs, l)
 	if drop {
@@ -210,7 +184,7 @@ func addHistogramMetric(
 
 func addSumMetric[N int64 | float64](
 	ch chan<- prometheus.Metric, sum metricdata.Sum[N], m metricdata.Metrics,
-	ks, vs [2]string, name string, mfs map[string]*dto.MetricFamily, l logger,
+	ks, vs []string, name string, mfs map[string]*dto.MetricFamily, l logger,
 ) {
 	valueType := prometheus.CounterValue
 	metricType := dto.MetricType_COUNTER
@@ -242,7 +216,7 @@ func addSumMetric[N int64 | float64](
 
 func addGaugeMetric[N int64 | float64](
 	ch chan<- prometheus.Metric, gauge metricdata.Gauge[N], m metricdata.Metrics,
-	ks, vs [2]string, name string, mfs map[string]*dto.MetricFamily, l logger,
+	ks, vs []string, name string, mfs map[string]*dto.MetricFamily, l logger,
 ) {
 	drop, help := validateMetrics(name, m.Description, dto.MetricType_GAUGE.Enum(), mfs, l)
 	if drop {
@@ -268,7 +242,7 @@ func addGaugeMetric[N int64 | float64](
 // getAttrs parses the attribute.Set to two lists of matching Prometheus-style
 // keys and values. It sanitizes invalid characters and handles duplicate keys
 // (due to sanitization) by sorting and concatenating the values following the spec.
-func getAttrs(attrs attribute.Set, ks, vs [2]string) ([]string, []string) {
+func getAttrs(attrs attribute.Set, ks, vs []string) ([]string, []string) {
 	keysMap := make(map[string][]string)
 	itr := attrs.Iter()
 	for itr.Next() {
@@ -292,7 +266,7 @@ func getAttrs(attrs attribute.Set, ks, vs [2]string) ([]string, []string) {
 		values = append(values, strings.Join(vals, ";"))
 	}
 
-	if ks[0] != "" {
+	if len(ks) > 0 {
 		keys = append(keys, ks[:]...)
 		values = append(values, vs[:]...)
 	}
@@ -300,15 +274,9 @@ func getAttrs(attrs attribute.Set, ks, vs [2]string) ([]string, []string) {
 }
 
 func (c *collector) createInfoMetric(name, description string, res *resource.Resource) (prometheus.Metric, error) {
-	keys, values := getAttrs(*res.Set(), [2]string{}, [2]string{})
+	keys, values := getAttrs(*res.Set(), []string{}, []string{})
 	desc := prometheus.NewDesc(name, description, keys, nil)
 	return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(1), values...)
-}
-
-func createScopeInfoMetric(scope instrumentation.Scope) (prometheus.Metric, error) {
-	keys := scopeInfoKeysRenamed[:]
-	desc := prometheus.NewDesc(scopeInfoMetricName, scopeInfoDescription, keys, nil)
-	return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(1), scope.Name, scope.Version)
 }
 
 func sanitizeRune(r rune) rune {
@@ -422,19 +390,4 @@ func validateMetrics(
 	}
 
 	return false, ""
-}
-
-func getScopeInfoValues(res *resource.Resource, scopeInfoKeys []string) []string {
-	scopeInfoValues := make([]string, len(scopeInfoKeys))
-
-	for i, key := range scopeInfoKeys {
-		for _, attr := range res.Attributes() {
-			if key == string(attr.Key) {
-				scopeInfoValues[i] = attr.Value.AsString()
-				break
-			}
-		}
-	}
-
-	return scopeInfoValues
 }

--- a/stats/internal/otel/prometheus/exporter.go
+++ b/stats/internal/otel/prometheus/exporter.go
@@ -53,7 +53,7 @@ var (
 	}
 	scopeInfoKeysMapping = map[string]string{
 		string(semconv.ServiceNameKey):       "job",
-		string(semconv.ServiceInstanceIDKey): "instance",
+		string(semconv.ServiceInstanceIDKey): "instanceName",
 	}
 	scopeInfoKeysRenamed = [2]string{
 		scopeInfoKeysMapping[scopeInfoKeys[0]],

--- a/stats/internal/otel/testdata/otel-collector-config.yaml
+++ b/stats/internal/otel/testdata/otel-collector-config.yaml
@@ -6,6 +6,8 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
+    resource_to_telemetry_conversion:
+      enabled: true
     const_labels:
       label1: value1
 

--- a/stats/otel.go
+++ b/stats/otel.go
@@ -65,7 +65,7 @@ func (s *otelStats) Start(ctx context.Context, goFactory GoRoutineFactory) error
 	if s.config.namespaceIdentifier != "" {
 		attrs = append(attrs, attribute.String("namespace", s.config.namespaceIdentifier))
 	}
-	res, err := otel.NewResource(s.config.serviceName, s.config.instanceName, s.config.serviceVersion, attrs...)
+	res, err := otel.NewResource(s.config.serviceName, s.config.serviceVersion, attrs...)
 	if err != nil {
 		return fmt.Errorf("failed to create open telemetry resource: %w", err)
 	}

--- a/stats/otel_test.go
+++ b/stats/otel_test.go
@@ -37,15 +37,13 @@ const (
 	metricsPort = "8889"
 )
 
-var (
-	globalDefaultAttrs = []*promClient.LabelPair{
-		{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
-		{Name: ptr("service_version"), Value: ptr("v1.2.3")},
-		{Name: ptr("telemetry_sdk_language"), Value: ptr("go")},
-		{Name: ptr("telemetry_sdk_name"), Value: ptr("opentelemetry")},
-		{Name: ptr("telemetry_sdk_version"), Value: ptr("1.14.0")},
-	}
-)
+var globalDefaultAttrs = []*promClient.LabelPair{
+	{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
+	{Name: ptr("service_version"), Value: ptr("v1.2.3")},
+	{Name: ptr("telemetry_sdk_language"), Value: ptr("go")},
+	{Name: ptr("telemetry_sdk_name"), Value: ptr("opentelemetry")},
+	{Name: ptr("telemetry_sdk_version"), Value: ptr("1.14.0")},
+}
 
 func TestOTelMeasurementInvalidOperations(t *testing.T) {
 	s := &otelStats{meter: global.MeterProvider().Meter(t.Name())}

--- a/stats/otel_test.go
+++ b/stats/otel_test.go
@@ -349,7 +349,7 @@ func TestOTelPeriodicStats(t *testing.T) {
 				// the label1=value1 is coming from the otel-collector-config.yaml (see const_labels)
 				{Name: ptr("label1"), Value: ptr("value1")},
 				{Name: ptr("job"), Value: ptr("TestOTelPeriodicStats")},
-				{Name: ptr("instance"), Value: ptr("my-instance-id")},
+				{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
 			}
 			if exp.tags != nil {
 				expectedLabels = append(expectedLabels, exp.tags...)
@@ -491,7 +491,7 @@ func TestOTelExcludedTags(t *testing.T) {
 		{Name: ptr("label1"), Value: ptr("value1")},
 		{Name: ptr("should_not_be_filtered"), Value: ptr("fancy-value")},
 		{Name: ptr("job"), Value: ptr("TestOTelExcludedTags")},
-		{Name: ptr("instance"), Value: ptr("my-instance-id")},
+		{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
 	}, metrics[metricName].Metric[0].Label, "Got %+v", metrics[metricName].Metric[0].Label)
 }
 
@@ -618,7 +618,7 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 			require.ElementsMatchf(t, append([]*promClient.LabelPair{
 				{Name: ptr("a"), Value: ptr("b")},
 				{Name: ptr("job"), Value: ptr("TestOTelHistogramBuckets")},
-				{Name: ptr("instance"), Value: ptr("my-instance-id")},
+				{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
 			}, scenario.additionalLabels...), metrics["foo"].Metric[0].Label, "Got %+v", metrics["foo"].Metric[0].Label)
 
 			require.EqualValues(t, ptr("bar"), metrics["bar"].Name)
@@ -635,7 +635,7 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 			require.ElementsMatchf(t, append([]*promClient.LabelPair{
 				{Name: ptr("c"), Value: ptr("d")},
 				{Name: ptr("job"), Value: ptr("TestOTelHistogramBuckets")},
-				{Name: ptr("instance"), Value: ptr("my-instance-id")},
+				{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
 			}, scenario.additionalLabels...), metrics["bar"].Metric[0].Label, "Got %+v", metrics["bar"].Metric[0].Label)
 
 			require.EqualValues(t, ptr("baz"), metrics["baz"].Name)
@@ -645,7 +645,7 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 			require.ElementsMatchf(t, append([]*promClient.LabelPair{
 				{Name: ptr("e"), Value: ptr("f")},
 				{Name: ptr("job"), Value: ptr("TestOTelHistogramBuckets")},
-				{Name: ptr("instance"), Value: ptr("my-instance-id")},
+				{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
 			}, scenario.additionalLabels...), metrics["baz"].Metric[0].Label, "Got %+v", metrics["baz"].Metric[0].Label)
 
 			require.EqualValues(t, ptr("qux"), metrics["qux"].Name)
@@ -655,7 +655,7 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 			require.ElementsMatchf(t, append([]*promClient.LabelPair{
 				{Name: ptr("g"), Value: ptr("h")},
 				{Name: ptr("job"), Value: ptr("TestOTelHistogramBuckets")},
-				{Name: ptr("instance"), Value: ptr("my-instance-id")},
+				{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
 			}, scenario.additionalLabels...), metrics["qux"].Metric[0].Label, "Got %+v", metrics["qux"].Metric[0].Label)
 
 			require.EqualValues(t, ptr("asd"), metrics["asd"].Name)
@@ -670,7 +670,7 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 			require.ElementsMatchf(t, append([]*promClient.LabelPair{
 				{Name: ptr("i"), Value: ptr("l")},
 				{Name: ptr("job"), Value: ptr("TestOTelHistogramBuckets")},
-				{Name: ptr("instance"), Value: ptr("my-instance-id")},
+				{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
 			}, scenario.additionalLabels...), metrics["asd"].Metric[0].Label, "Got %+v", metrics["asd"].Metric[0].Label)
 		})
 	}
@@ -735,7 +735,7 @@ func TestPrometheusCustomRegistry(t *testing.T) {
 		require.ElementsMatchf(t, []*promClient.LabelPair{
 			{Name: ptr("a"), Value: ptr("b")},
 			{Name: ptr("job"), Value: ptr("TestPrometheusCustomRegistry")},
-			{Name: ptr("instance"), Value: ptr("my-instance-id")},
+			{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
 		}, metrics[metricName].Metric[0].Label, "Got %+v", metrics[metricName].Metric[0].Label)
 	})
 
@@ -758,7 +758,7 @@ func TestPrometheusCustomRegistry(t *testing.T) {
 		require.ElementsMatch(t, []*promClient.LabelPair{
 			{Name: ptr("a"), Value: ptr("b")},
 			{Name: ptr("job"), Value: ptr("TestPrometheusCustomRegistry")},
-			{Name: ptr("instance"), Value: ptr("my-instance-id")},
+			{Name: ptr("instanceName"), Value: ptr("my-instance-id")},
 		}, mf.GetMetric()[0].GetLabel())
 		require.EqualValues(t, ptr(7.0), mf.GetMetric()[0].GetCounter().Value)
 	})

--- a/stats/testdata/otel-collector-config.yaml
+++ b/stats/testdata/otel-collector-config.yaml
@@ -6,6 +6,8 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
+    resource_to_telemetry_conversion:
+      enabled: true
     const_labels:
       label1: value1
 


### PR DESCRIPTION
# Description

Small refactoring to have the service instance ID consistent across all 3 stats modes under the label `instanceName`. I also simplified a bit the prometheus exporter and removed an unnecessary metric (i.e. `otel_scope_info`) that was giving me troubles with the tests and that we are not using nor planning to use.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Fix-instanceName-across-stats-27f92841d5d3450d8ff83cd20cf32031)>

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
