### PR TITLE
fix: otel prometheus duplicated attributes

### DIFF
--- a/stats/internal/otel/prometheus/exporter.go
+++ b/stats/internal/otel/prometheus/exporter.go
@@ -254,7 +254,7 @@ func addGaugeMetric[N int64 | float64](
 // keys and values. It sanitizes invalid characters and handles duplicate keys
 // (due to sanitization) by removing and reporting the duplicates so that we
 // can be compatible with the gRPC implementation that does not concatenate
-// duplicate values.
+// duplicated keys.
 func getAttrs(attrs attribute.Set, scopeKeys, scopeValues []string) ([]string, []string, []string) {
 	var (
 		dups    []string

--- a/stats/internal/otel/prometheus/exporter.go
+++ b/stats/internal/otel/prometheus/exporter.go
@@ -16,7 +16,8 @@
 //
 //  4. removed unnecessary otel_scope_info metric
 //
-//  5. added logic to detect duplicated attributes
+//  5. added logic to remove and detect duplicated attributes (instead of concatenating them to stay compatible
+//     with gRPC)
 package prometheus
 
 import (


### PR DESCRIPTION
# Description

This is to address an error that happens when the same label is set both at the resource level and at the metric label. 
The underlying Prometheus client is the one raising the error [here](https://github.com/prometheus/client_golang/blob/main/prometheus/desc.go#L140).

The proposal is to remove the duplicate at the metric level (so the resource will take precedence) and to log it in order to take action if needed/wanted.

In the gRPC version the resource attributes take precedence and the metric is not lost.

## Notion Ticket

< [Notion Link](https://www.notion.so/rudderstacks/Deploy-otel-to-prousmt-cc0a56cc658c4a2f985fe766e71ca83c) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
