### PR TITLE
feat: package diskutils and timeutils

### DIFF
--- a/diskutils/diskutils.go
+++ b/diskutils/diskutils.go
@@ -1,0 +1,110 @@
+package diskutils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+)
+
+// CreateTMPDIR creates tmp dir at path configured via RUDDER_TMPDIR env var
+func CreateTMPDIR() (string, error) {
+	tmpdirPath := strings.TrimSuffix(config.GetString("RUDDER_TMPDIR", ""), "/")
+	// second chance: fallback to /tmp if this folder exists
+	if tmpdirPath == "" {
+		fallbackPath := "/tmp"
+		_, err := os.Stat(fallbackPath)
+		if err == nil {
+			tmpdirPath = fallbackPath
+		}
+	}
+	if tmpdirPath == "" {
+		return os.UserHomeDir()
+	}
+	return tmpdirPath, nil
+}
+
+func GetBadgerDBUsage(dir string) (int64, int64, int64, error) {
+	// Notes
+	// Instead of using BadgerDB's internal function to get the disk usage, we are writing our own implementation because of the following reasons:
+	// 1. BadgerDB internally creates a sparse memory backed file to store the data
+	// 2. The size returned by the filepath.Walk used internally gives a misleading size because the file is mostly empty and doesn't consume any disk space
+	lsmSize, err := DiskUsage(dir, ".sst")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	vlogSize, err := DiskUsage(dir, ".vlog")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	totSize, err := DiskUsage(dir)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return lsmSize, vlogSize, totSize, nil
+}
+
+// DiskUsage calculates the path's disk usage recursively in bytes. If exts are provided, only files with matching extensions will be included in the result.
+func DiskUsage(path string, ext ...string) (int64, error) {
+	var totSize int64
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		size, _ := GetDiskUsageOfFile(path)
+		if len(ext) == 0 {
+			totSize += size
+		} else {
+			for _, e := range ext {
+				if filepath.Ext(path) == e {
+					totSize += size
+				}
+			}
+		}
+		return nil
+	})
+	return totSize, err
+}
+
+func GetDiskUsageOfFile(path string) (int64, error) {
+	// Notes
+	// 1. stat.Blocks is the number of stat.Blksize blocks allocated to the file
+	// 2. stat.Blksize is the filesystem block size for this filesystem
+	// 3. We compute the actual disk usage of a (sparse) file by multiplying the number of blocks allocated to the file with the block size. This computes a different value than the one returned by stat.Size particularly for sparse files.
+	var stat syscall.Stat_t
+	err := syscall.Stat(path, &stat)
+	if err != nil {
+		return 0, fmt.Errorf("unable to get file size %w", err)
+	}
+	return int64(stat.Blksize) * stat.Blocks / 8, nil //nolint:unconvert // In amd64 architecture stat.Blksize is int64 whereas in arm64 it is int32
+}
+
+// FolderExists Check if folder exists at particular path
+func FolderExists(path string) (bool, error) {
+	fileInfo, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return fileInfo.IsDir(), nil
+}
+
+// FileExists Check if file exists at particular path
+func FileExists(path string) (bool, error) {
+	fileInfo, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return !fileInfo.IsDir(), nil
+}

--- a/diskutils/diskutils_test.go
+++ b/diskutils/diskutils_test.go
@@ -1,0 +1,58 @@
+package diskutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func initMisc() {
+	config.Reset()
+	logger.Reset()
+}
+
+func Test_CreteTempDir(t *testing.T) {
+	initMisc()
+	tmpDirPath, err := CreateTMPDIR()
+	require.NoError(t, err)
+	folderExists, err := FolderExists(tmpDirPath)
+	require.NoError(t, err)
+	require.True(t, folderExists)
+}
+
+func TestGetDiskUsage(t *testing.T) {
+	initMisc()
+	// Create a temp file
+	tmpDirPath := t.TempDir()
+	tempFilePath := filepath.Join(tmpDirPath, "tempFileForDiskUsage")
+	f, err := os.OpenFile(tempFilePath, os.O_CREATE|os.O_RDWR, 0o755) // skipcq: GSC-G302
+	require.NoError(t, err)
+
+	defer func() { _ = f.Close() }()
+	defer func() { _ = os.Remove(tempFilePath) }()
+
+	err = f.Truncate(1024 * 1024)
+	require.NoError(t, err)
+
+	fileSize, err := os.Stat(tempFilePath)
+	require.NoError(t, err)
+	fileDiskUsage, err := GetDiskUsageOfFile(tempFilePath)
+	require.NoError(t, err)
+	require.EqualValues(t, 1024*1024, fileSize.Size())
+	require.EqualValues(t, 0, fileDiskUsage)
+
+	// write some bytes into the file
+	_, err = f.WriteString("test")
+	require.NoError(t, err)
+	fileSize, err = os.Stat(tempFilePath)
+	require.NoError(t, err)
+	fileDiskUsage, err = GetDiskUsageOfFile(tempFilePath)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 1024*1024, fileSize.Size())
+	require.Greater(t, fileDiskUsage, int64(0))
+}

--- a/timeutil/timeutil.go
+++ b/timeutil/timeutil.go
@@ -1,0 +1,40 @@
+package timeutil
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// MinsOfDay returns minutes since start of day for a timestamp in format `15:30`
+// eg. MinsOfDay("02:30") -> 150
+// returns 0 for a timestamp not in format HH:MM
+func MinsOfDay(str string) int {
+	matched, err := regexp.MatchString("^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$", str)
+	if err != nil || !matched {
+		return 0
+	}
+	x := strings.Split(str, ":")
+	hrs, _ := strconv.Atoi(x[0])
+	mins, _ := strconv.Atoi(x[1])
+	return (hrs * 60) + mins
+}
+
+// StartOfDay returns start of the day
+func StartOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}
+
+// Now returns the current time in UTC.
+func Now() time.Time {
+	return time.Now().UTC()
+}
+
+// GetElapsedMinsInThisDay() returns no of minutes elapsed in this day for the time provided
+func GetElapsedMinsInThisDay(currentTime time.Time) int {
+	hour := currentTime.Hour()
+	minute := currentTime.Minute()
+	return MinsOfDay(fmt.Sprintf("%d:%d", hour, minute))
+}

--- a/timeutil/timeutil_test.go
+++ b/timeutil/timeutil_test.go
@@ -1,0 +1,36 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MinsOfDay(t *testing.T) {
+	require.Equal(t, MinsOfDay("00:00"), 0)
+	require.Equal(t, MinsOfDay("00:01"), 1)
+	require.Equal(t, MinsOfDay("00:59"), 59)
+	require.Equal(t, MinsOfDay("01:00"), 60)
+	require.Equal(t, MinsOfDay("23:59"), 1439)
+	require.Equal(t, MinsOfDay("26:00"), 0)
+}
+
+func Test_StartOfDay(t *testing.T) {
+	require.Equal(t, StartOfDay(time.Date(2023, 11, 4, 5, 23, 43, 3, time.Local)), time.Date(2023, time.November, 4, 0, 0, 0, 0, time.Local))
+	require.Equal(t, StartOfDay(time.Date(2023, 12, 4, 5, 23, 43, 3, time.UTC)), time.Date(2023, time.December, 4, 0, 0, 0, 0, time.UTC))
+	require.Equal(t, StartOfDay(time.Date(2023, 15, 4, 5, 23, 43, 3, time.Local)), time.Date(2024, time.March, 4, 0, 0, 0, 0, time.Local))
+}
+
+func Test_Now(t *testing.T) {
+	require.InDelta(t, Now().Unix(), time.Now().UTC().Unix(), 1000)
+}
+
+func Test_GetElapsedMinsInThisDay(t *testing.T) {
+	require.Equal(t, GetElapsedMinsInThisDay(time.Date(2023, 11, 4, 5, 23, 43, 3, time.Local)), 323)
+	require.Equal(t, GetElapsedMinsInThisDay(time.Date(2023, 12, 4, 5, 25, 43, 3, time.UTC)), 325)
+	// Giving an invalid month as input also does return the correct value
+	require.Equal(t, GetElapsedMinsInThisDay(time.Date(2023, 15, 4, 5, 33, 43, 3, time.Local)), 333)
+	// Providing an incorrect time does return 0
+	require.Equal(t, GetElapsedMinsInThisDay(time.Date(2023, 15, 4, 5, 63, 43, 3, time.Local)), 0)
+}


### PR DESCRIPTION
# Description

Breaking the misc package and move all the functions interacting with disk to disk utils on rudder-go-kit
Also moving timeutils in rudder-server to the go-kit

## Notion Ticket

[Notion Link](https://www.notion.so/rudderstacks/upgrade-to-badgerV4-86d09c352df94fd5b6c6c109eafc1271?pvs=4)

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
