### PR TITLE
fix: s3 manager data race

### DIFF
--- a/filemanager/s3manager_test.go
+++ b/filemanager/s3manager_test.go
@@ -92,7 +92,7 @@ func TestNewS3ManagerWithBothAccessKeysAndRoleButRoleBasedAuthFalse(t *testing.T
 }
 
 func TestGetSessionWithAccessKeys(t *testing.T) {
-	s3Manager := s3Manager{
+	s3Manager := S3Manager{
 		baseManager: &baseManager{
 			logger: logger.NOP,
 		},
@@ -113,7 +113,7 @@ func TestGetSessionWithAccessKeys(t *testing.T) {
 }
 
 func TestGetSessionWithIAMRole(t *testing.T) {
-	s3Manager := s3Manager{
+	s3Manager := S3Manager{
 		baseManager: &baseManager{
 			logger: logger.NOP,
 		},


### PR DESCRIPTION
# Description

Fixing data race. Additional changes include:

* Exporting type to allow for variable declaration. Encapsulation is preserved.
* Breaking some long lines.
* Removed `defer` inside `for` loop (bad practice).
* Generalized error casting instead of using `awserr`.
* Removed dependency to `awserr`.

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-115/s3-manager-data-race) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
