### PR TITLE
fix: register reloadable config variables

### DIFF
--- a/config/atomic_benchmark_test.go
+++ b/config/atomic_benchmark_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func BenchmarkAtomic(b *testing.B) {
+	b.Run("mutex", func(b *testing.B) {
+		var v atomicMutex[int]
+		go func() {
+			for {
+				v.Store(1)
+				time.Sleep(time.Millisecond)
+			}
+		}()
+		for i := 0; i < b.N; i++ {
+			_ = v.Load()
+		}
+	})
+	b.Run("rw mutex", func(b *testing.B) {
+		var v atomicRWMutex[int]
+		go func() {
+			for {
+				v.Store(1)
+				time.Sleep(time.Millisecond)
+			}
+		}()
+		for i := 0; i < b.N; i++ {
+			_ = v.Load()
+		}
+	})
+	b.Run("atomic", func(b *testing.B) {
+		var v atomicValue[int]
+		go func() {
+			for {
+				v.Store(1)
+				time.Sleep(time.Millisecond)
+			}
+		}()
+		for i := 0; i < b.N; i++ {
+			_ = v.Load()
+		}
+	})
+}
+
+type atomicMutex[T comparable] struct {
+	value T
+	lock  sync.Mutex
+}
+
+func (a *atomicMutex[T]) Load() T {
+	a.lock.Lock()
+	v := a.value
+	a.lock.Unlock()
+	return v
+}
+
+func (a *atomicMutex[T]) Store(v T) {
+	a.lock.Lock()
+	a.value = v
+	a.lock.Unlock()
+}
+
+type atomicRWMutex[T comparable] struct {
+	value T
+	lock  sync.RWMutex
+}
+
+func (a *atomicRWMutex[T]) Load() T {
+	a.lock.RLock()
+	v := a.value
+	a.lock.RUnlock()
+	return v
+}
+
+func (a *atomicRWMutex[T]) Store(v T) {
+	a.lock.Lock()
+	a.value = v
+	a.lock.Unlock()
+}
+
+type atomicValue[T comparable] struct {
+	atomic.Value
+}
+
+func (a *atomicValue[T]) Load() (zero T) {
+	v := a.Value.Load()
+	if v == nil {
+		return zero
+	}
+	return v.(T)
+}
+
+func (a *atomicValue[T]) Store(v T) {
+	a.Value.Store(v)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -281,19 +281,23 @@ func getAtomicMapKeys[T configTypes](v T, keys ...string) (string, string) {
 }
 
 func getOrCreatePointer[T configTypes](
-	m map[string]any, dvs map[string]string, lock *sync.RWMutex, defaultValue T, keys ...string,
+	mapPtr *map[string]any, dvsMapPtr *map[string]string, // using pointers to maps so that we can run "make" here
+	lock *sync.RWMutex, defaultValue T, keys ...string,
 ) *Atomic[T] {
 	key, dvKey := getAtomicMapKeys(defaultValue, keys...)
 
 	lock.Lock()
 	defer lock.Unlock()
 
-	if m == nil {
-		m = make(map[string]any)
+	if *mapPtr == nil {
+		*mapPtr = make(map[string]any)
 	}
-	if dvs == nil {
-		dvs = make(map[string]string)
+	if *dvsMapPtr == nil {
+		*dvsMapPtr = make(map[string]string)
 	}
+
+	m := *mapPtr
+	dvs := *dvsMapPtr
 
 	defer func() {
 		if _, ok := dvs[key]; !ok {

--- a/config/config.go
+++ b/config/config.go
@@ -276,7 +276,7 @@ func (c *Config) Set(key string, value interface{}) {
 
 func getAtomicMapKeys[T configTypes](v T, keys ...string) (string, string) {
 	sort.Strings(keys)
-	k := fmt.Sprintf("%T:%s", v, strings.Join(keys, ""))
+	k := fmt.Sprintf("%T:%s", v, strings.Join(keys, ","))
 	return k, fmt.Sprintf("%s:%v", k, v)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -306,7 +306,7 @@ func getOrCreatePointer[T configTypes](
 		if dvs[key] != dvKey {
 			panic(fmt.Errorf(
 				"Detected misuse of atomic variable registered with different default values %+v - %+v\n",
-				defaultValue, dvKey,
+				dvs[key], dvKey,
 			))
 		}
 	}()

--- a/config/config.go
+++ b/config/config.go
@@ -273,17 +273,12 @@ func (c *Config) Set(key string, value interface{}) {
 	c.onConfigChange()
 }
 
-func getAtomicMapKey(v any, keys ...string) string {
-	switch v.(type) {
-	case int, int64, string, time.Duration, bool, float64, []string, map[string]interface{}:
-		sort.Strings(keys)
-		return fmt.Sprintf("%T:%s", v, strings.Join(keys, ""))
-	default:
-		panic(fmt.Errorf("getAtomicMapKey: unsupported type %T", v))
-	}
+func getAtomicMapKey[T configTypes](v T, keys ...string) string {
+	sort.Strings(keys)
+	return fmt.Sprintf("%T:%s", v, strings.Join(keys, ""))
 }
 
-func getOrCreatePointer[T any](m map[string]any, lock *sync.RWMutex, defaultValue T, keys ...string) *Atomic[T] {
+func getOrCreatePointer[T configTypes](m map[string]any, lock *sync.RWMutex, defaultValue T, keys ...string) *Atomic[T] {
 	key := getAtomicMapKey(defaultValue, keys...)
 
 	lock.Lock()
@@ -297,9 +292,9 @@ func getOrCreatePointer[T any](m map[string]any, lock *sync.RWMutex, defaultValu
 		return p.(*Atomic[T])
 	}
 
-	ptr := &Atomic[T]{}
-	m[key] = ptr
-	return ptr
+	p := &Atomic[T]{}
+	m[key] = p
+	return p
 }
 
 // bindEnv handles rudder server's unique snake case replacement by registering

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -214,10 +214,10 @@ func TestCheckAndHotReloadConfig(t *testing.T) {
 	})
 }
 
-func TestAtomicHotReload(t *testing.T) {
+func TestRegisterReloadable(t *testing.T) {
 	t.Run("int", func(t *testing.T) {
 		c := New()
-		v := c.RegisterAtomicIntVar(5, 1, t.Name())
+		v := c.RegisterReloadableIntVar(5, 1, t.Name())
 		require.Equal(t, 5, v.Load())
 
 		c.Set(t.Name(), 10)
@@ -225,7 +225,7 @@ func TestAtomicHotReload(t *testing.T) {
 	})
 	t.Run("int64", func(t *testing.T) {
 		c := New()
-		v := c.RegisterAtomicInt64Var(5, 1, t.Name())
+		v := c.RegisterReloadableInt64Var(5, 1, t.Name())
 		require.EqualValues(t, 5, v.Load())
 
 		c.Set(t.Name(), 10)
@@ -233,7 +233,7 @@ func TestAtomicHotReload(t *testing.T) {
 	})
 	t.Run("bool", func(t *testing.T) {
 		c := New()
-		v := c.RegisterAtomicBoolVar(true, t.Name())
+		v := c.RegisterReloadableBoolVar(true, t.Name())
 		require.True(t, v.Load())
 
 		c.Set(t.Name(), false)
@@ -241,7 +241,7 @@ func TestAtomicHotReload(t *testing.T) {
 	})
 	t.Run("float64", func(t *testing.T) {
 		c := New()
-		v := c.RegisterAtomicFloat64Var(0.123, t.Name())
+		v := c.RegisterReloadableFloat64Var(0.123, t.Name())
 		require.EqualValues(t, 0.123, v.Load())
 
 		c.Set(t.Name(), 4.567)
@@ -249,7 +249,7 @@ func TestAtomicHotReload(t *testing.T) {
 	})
 	t.Run("string", func(t *testing.T) {
 		c := New()
-		v := c.RegisterAtomicStringVar("foo", t.Name())
+		v := c.RegisterReloadableStringVar("foo", t.Name())
 		require.Equal(t, "foo", v.Load())
 
 		c.Set(t.Name(), "bar")
@@ -257,7 +257,7 @@ func TestAtomicHotReload(t *testing.T) {
 	})
 	t.Run("duration", func(t *testing.T) {
 		c := New()
-		v := c.RegisterAtomicDurationVar(123, 1, t.Name())
+		v := c.RegisterReloadableDurationVar(123, 1, t.Name())
 		require.Equal(t, 123*time.Nanosecond, v.Load())
 
 		c.Set(t.Name(), 456*time.Millisecond)
@@ -265,7 +265,7 @@ func TestAtomicHotReload(t *testing.T) {
 	})
 	t.Run("[]string", func(t *testing.T) {
 		c := New()
-		v := c.RegisterAtomicStringSliceVar([]string{"a", "b"}, t.Name())
+		v := c.RegisterReloadableStringSliceVar([]string{"a", "b"}, t.Name())
 		require.Equal(t, []string{"a", "b"}, v.Load())
 
 		c.Set(t.Name(), []string{"c", "d"})
@@ -273,7 +273,7 @@ func TestAtomicHotReload(t *testing.T) {
 	})
 	t.Run("map[string]interface{}", func(t *testing.T) {
 		c := New()
-		v := c.RegisterAtomicStringMapVar(map[string]interface{}{"a": 1, "b": 2}, t.Name())
+		v := c.RegisterReloadableStringMapVar(map[string]interface{}{"a": 1, "b": 2}, t.Name())
 		require.Equal(t, map[string]interface{}{"a": 1, "b": 2}, v.Load())
 
 		c.Set(t.Name(), map[string]interface{}{"c": 3, "d": 4})
@@ -297,7 +297,7 @@ func TestGetOrCreatePointer(t *testing.T) {
 	require.True(t, p1 != p3)
 
 	require.PanicsWithError(t,
-		"Detected misuse of atomic variable registered with different default values "+
+		"Detected misuse of reloadable variable registered with different default values "+
 			"int:bar,foo,qux:123 - int:bar,foo,qux:456\n",
 		func() {
 			getOrCreatePointer(m, dvs, &rwm, 456, "qux", "foo", "bar")
@@ -305,14 +305,14 @@ func TestGetOrCreatePointer(t *testing.T) {
 	)
 }
 
-func TestAtomic(t *testing.T) {
+func TestReloadable(t *testing.T) {
 	t.Run("scalar", func(t *testing.T) {
-		var v Atomic[int]
+		var v Reloadable[int]
 		v.store(123)
 		require.Equal(t, 123, v.Load())
 	})
 	t.Run("nullable", func(t *testing.T) {
-		var v Atomic[[]string]
+		var v Reloadable[[]string]
 		require.Nil(t, v.Load())
 
 		v.store(nil)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -306,6 +306,9 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), 10)
 			require.Equal(t, 10, v.Load())
+
+			c.Set(t.Name(), 10)
+			require.Equal(t, 10, v.Load(), "value should not change")
 		})
 		t.Run("int64", func(t *testing.T) {
 			c := New()
@@ -314,6 +317,9 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), 10)
 			require.EqualValues(t, 10, v.Load())
+
+			c.Set(t.Name(), 10)
+			require.EqualValues(t, 10, v.Load(), "value should not change")
 		})
 		t.Run("bool", func(t *testing.T) {
 			c := New()
@@ -322,6 +328,9 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), false)
 			require.False(t, v.Load())
+
+			c.Set(t.Name(), false)
+			require.False(t, v.Load(), "value should not change")
 		})
 		t.Run("float64", func(t *testing.T) {
 			c := New()
@@ -330,6 +339,9 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), 4.567)
 			require.EqualValues(t, 4.567, v.Load())
+
+			c.Set(t.Name(), 4.567)
+			require.EqualValues(t, 4.567, v.Load(), "value should not change")
 		})
 		t.Run("string", func(t *testing.T) {
 			c := New()
@@ -338,6 +350,9 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), "bar")
 			require.EqualValues(t, "bar", v.Load())
+
+			c.Set(t.Name(), "bar")
+			require.EqualValues(t, "bar", v.Load(), "value should not change")
 		})
 		t.Run("duration", func(t *testing.T) {
 			c := New()
@@ -346,6 +361,9 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), 456*time.Millisecond)
 			require.Equal(t, 456*time.Millisecond, v.Load())
+
+			c.Set(t.Name(), 456*time.Millisecond)
+			require.Equal(t, 456*time.Millisecond, v.Load(), "value should not change")
 
 			require.PanicsWithError(t,
 				"Detected misuse of config variable registered with different default values "+
@@ -363,6 +381,9 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), []string{"c", "d"})
 			require.Equal(t, []string{"c", "d"}, v.Load())
+
+			c.Set(t.Name(), []string{"c", "d"})
+			require.Equal(t, []string{"c", "d"}, v.Load(), "value should not change")
 		})
 		t.Run("map[string]interface{}", func(t *testing.T) {
 			c := New()
@@ -371,6 +392,9 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), map[string]interface{}{"c": 3, "d": 4})
 			require.Equal(t, map[string]interface{}{"c": 3, "d": 4}, v.Load())
+
+			c.Set(t.Name(), map[string]interface{}{"c": 3, "d": 4})
+			require.Equal(t, map[string]interface{}{"c": 3, "d": 4}, v.Load(), "value should not change")
 		})
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -290,17 +290,20 @@ func TestGetOrCreatePointer(t *testing.T) {
 	p1 := getOrCreatePointer(m, dvs, &rwm, 123, "foo", "bar")
 	require.NotNil(t, p1)
 
-	p2 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo")
+	p2 := getOrCreatePointer(m, dvs, &rwm, 123, "foo", "bar")
 	require.True(t, p1 == p2)
 
-	p3 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo", "qux")
+	p3 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo")
 	require.True(t, p1 != p3)
+
+	p4 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo", "qux")
+	require.True(t, p1 != p4)
 
 	require.PanicsWithError(t,
 		"Detected misuse of reloadable variable registered with different default values "+
 			"int:bar,foo,qux:123 - int:bar,foo,qux:456\n",
 		func() {
-			getOrCreatePointer(m, dvs, &rwm, 456, "qux", "foo", "bar")
+			getOrCreatePointer(m, dvs, &rwm, 456, "bar", "foo", "qux")
 		},
 	)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -224,6 +224,15 @@ func TestAtomicHotReload(t *testing.T) {
 
 		require.Equal(t, 10, v.Load())
 	})
+	t.Run("bool", func(t *testing.T) {
+		var v Atomic[bool]
+
+		c := New()
+		c.RegisterAtomicBoolVar(false, &v, t.Name())
+		c.Set(t.Name(), true)
+
+		require.True(t, v.Load())
+	})
 	t.Run("duration", func(t *testing.T) {
 		var v Atomic[time.Duration]
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -297,7 +297,8 @@ func TestGetOrCreatePointer(t *testing.T) {
 	require.True(t, p1 != p3)
 
 	require.PanicsWithError(t,
-		"Detected misuse of atomic variable registered with different default values 456 - int:barfooqux:456\n",
+		"Detected misuse of atomic variable registered with different default values "+
+			"int:barfooqux:123 - int:barfooqux:456\n",
 		func() {
 			getOrCreatePointer(&m, &dvs, &rwm, 456, "qux", "foo", "bar")
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -300,20 +300,20 @@ func TestAtomicHotReload(t *testing.T) {
 func TestAtomic(t *testing.T) {
 	t.Run("scalar", func(t *testing.T) {
 		var v Atomic[int]
-		v.Store(123)
+		v.store(123)
 		require.Equal(t, 123, v.Load())
 	})
 	t.Run("interface", func(t *testing.T) {
 		var v Atomic[error]
 		require.Nil(t, v.Load())
 
-		v.Store(nil)
+		v.store(nil)
 		require.Nil(t, v.Load())
 
-		v.Store(errors.New("some error"))
+		v.store(errors.New("some error"))
 		require.EqualError(t, v.Load(), "some error")
 
-		v.Store(nil)
+		v.store(nil)
 		require.Nil(t, v.Load())
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -219,28 +219,41 @@ func TestAtomicHotReload(t *testing.T) {
 		var v Atomic[int]
 
 		c := New()
-		c.RegisterAtomicIntVar(0, &v, 1, t.Name())
-		c.Set(t.Name(), 10)
+		c.RegisterAtomicIntVar(5, &v, 1, t.Name())
+		require.Equal(t, 5, v.Load())
 
+		c.Set(t.Name(), 10)
 		require.Equal(t, 10, v.Load())
 	})
 	t.Run("bool", func(t *testing.T) {
 		var v Atomic[bool]
 
 		c := New()
-		c.RegisterAtomicBoolVar(false, &v, t.Name())
-		c.Set(t.Name(), true)
-
+		c.RegisterAtomicBoolVar(true, &v, t.Name())
 		require.True(t, v.Load())
+
+		c.Set(t.Name(), false)
+		require.False(t, v.Load())
+	})
+	t.Run("float64", func(t *testing.T) {
+		var v Atomic[float64]
+
+		c := New()
+		c.RegisterAtomicFloat64Var(0.123, &v, t.Name())
+		require.EqualValues(t, 0.123, v.Load())
+
+		c.Set(t.Name(), 4.567)
+		require.EqualValues(t, 4.567, v.Load())
 	})
 	t.Run("duration", func(t *testing.T) {
 		var v Atomic[time.Duration]
 
 		c := New()
-		c.RegisterAtomicDurationVar(0, &v, 1, t.Name())
-		c.Set(t.Name(), 123*time.Millisecond)
+		c.RegisterAtomicDurationVar(123, &v, 1, t.Name())
+		require.Equal(t, 123*time.Nanosecond, v.Load())
 
-		require.Equal(t, 123*time.Millisecond, v.Load())
+		c.Set(t.Name(), 456*time.Millisecond)
+		require.Equal(t, 456*time.Millisecond, v.Load())
 	})
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -225,6 +225,16 @@ func TestAtomicHotReload(t *testing.T) {
 		c.Set(t.Name(), 10)
 		require.Equal(t, 10, v.Load())
 	})
+	t.Run("int64", func(t *testing.T) {
+		var v Atomic[int64]
+
+		c := New()
+		c.RegisterAtomicInt64Var(5, &v, 1, t.Name())
+		require.EqualValues(t, 5, v.Load())
+
+		c.Set(t.Name(), 10)
+		require.EqualValues(t, 10, v.Load())
+	})
 	t.Run("bool", func(t *testing.T) {
 		var v Atomic[bool]
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -298,7 +298,7 @@ func TestGetOrCreatePointer(t *testing.T) {
 
 	require.PanicsWithError(t,
 		"Detected misuse of atomic variable registered with different default values "+
-			"int:barfooqux:123 - int:barfooqux:456\n",
+			"int:bar,foo,qux:123 - int:bar,foo,qux:456\n",
 		func() {
 			getOrCreatePointer(&m, &dvs, &rwm, 456, "qux", "foo", "bar")
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -255,6 +255,16 @@ func TestAtomicHotReload(t *testing.T) {
 		c.Set(t.Name(), 4.567)
 		require.EqualValues(t, 4.567, v.Load())
 	})
+	t.Run("string", func(t *testing.T) {
+		var v Atomic[string]
+
+		c := New()
+		c.RegisterAtomicStringVar("foo", &v, t.Name())
+		require.Equal(t, "foo", v.Load())
+
+		c.Set(t.Name(), "bar")
+		require.EqualValues(t, "bar", v.Load())
+	})
 	t.Run("duration", func(t *testing.T) {
 		var v Atomic[time.Duration]
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -283,24 +283,24 @@ func TestAtomicHotReload(t *testing.T) {
 
 func TestGetOrCreatePointer(t *testing.T) {
 	var (
-		m   map[string]any
-		dvs map[string]string
+		m   = make(map[string]any)
+		dvs = make(map[string]string)
 		rwm sync.RWMutex
 	)
-	p1 := getOrCreatePointer(&m, &dvs, &rwm, 123, "foo", "bar")
+	p1 := getOrCreatePointer(m, dvs, &rwm, 123, "foo", "bar")
 	require.NotNil(t, p1)
 
-	p2 := getOrCreatePointer(&m, &dvs, &rwm, 123, "bar", "foo")
+	p2 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo")
 	require.True(t, p1 == p2)
 
-	p3 := getOrCreatePointer(&m, &dvs, &rwm, 123, "bar", "foo", "qux")
+	p3 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo", "qux")
 	require.True(t, p1 != p3)
 
 	require.PanicsWithError(t,
 		"Detected misuse of atomic variable registered with different default values "+
 			"int:bar,foo,qux:123 - int:bar,foo,qux:456\n",
 		func() {
-			getOrCreatePointer(&m, &dvs, &rwm, 456, "qux", "foo", "bar")
+			getOrCreatePointer(m, dvs, &rwm, 456, "qux", "foo", "bar")
 		},
 	)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -231,6 +232,27 @@ func TestAtomicHotReload(t *testing.T) {
 		c.Set(t.Name(), 123*time.Millisecond)
 
 		require.Equal(t, 123*time.Millisecond, v.Load())
+	})
+}
+
+func TestAtomic(t *testing.T) {
+	t.Run("scalar", func(t *testing.T) {
+		var v Atomic[int]
+		v.Store(123)
+		require.Equal(t, 123, v.Load())
+	})
+	t.Run("interface", func(t *testing.T) {
+		var v Atomic[error]
+		require.Nil(t, v.Load())
+
+		v.Store(nil)
+		require.Nil(t, v.Load())
+
+		v.Store(errors.New("some error"))
+		require.EqualError(t, v.Load(), "some error")
+
+		v.Store(nil)
+		require.Nil(t, v.Load())
 	})
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -219,83 +219,50 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 		t.Run("int", func(t *testing.T) {
 			c := New()
 			v := c.RegisterIntVar(5, 1, t.Name())
-			require.NotNil(t, v)
-			require.Equal(t, 5, *v)
-
-			c.Set(t.Name(), 10)
-			require.Equal(t, 5, *v, "variable is not reloadable")
+			require.Equal(t, 5, v)
 		})
 		t.Run("int64", func(t *testing.T) {
 			c := New()
 			v := c.RegisterInt64Var(5, 1, t.Name())
-			require.NotNil(t, v)
-			require.EqualValues(t, 5, *v)
-
-			c.Set(t.Name(), 10)
-			require.EqualValues(t, 5, *v, "variable is not reloadable")
+			require.EqualValues(t, 5, v)
 		})
 		t.Run("bool", func(t *testing.T) {
 			c := New()
 			v := c.RegisterBoolVar(true, t.Name())
-			require.NotNil(t, v)
-			require.True(t, *v)
-
-			c.Set(t.Name(), false)
-			require.True(t, *v, "variable is not reloadable")
+			require.True(t, v)
 		})
 		t.Run("float64", func(t *testing.T) {
 			c := New()
 			v := c.RegisterFloat64Var(0.123, t.Name())
-			require.NotNil(t, v)
-			require.EqualValues(t, 0.123, *v)
-
-			c.Set(t.Name(), 4.567)
-			require.EqualValues(t, 0.123, *v, "variable is not reloadable")
+			require.EqualValues(t, 0.123, v)
 		})
 		t.Run("string", func(t *testing.T) {
 			c := New()
 			v := c.RegisterStringVar("foo", t.Name())
-			require.NotNil(t, v)
-			require.Equal(t, "foo", *v)
-
-			c.Set(t.Name(), "bar")
-			require.EqualValues(t, "foo", *v, "variable is not reloadable")
+			require.Equal(t, "foo", v)
 		})
 		t.Run("duration", func(t *testing.T) {
 			c := New()
 			v := c.RegisterDurationVar(123, time.Second, t.Name())
-			require.NotNil(t, v)
-			require.Equal(t, 123*time.Second, *v)
-
-			c.Set(t.Name(), 456*time.Millisecond)
-			require.Equal(t, 123*time.Second, *v, "variable is not reloadable")
-
-			require.PanicsWithError(t,
-				"Detected misuse of config variable registered with different default values "+
-					"time.Duration:TestRegisterNewReloadableAPI/non_reloadable/duration:2m3s - "+
-					"time.Duration:TestRegisterNewReloadableAPI/non_reloadable/duration:124ms\n",
-				func() {
-					_ = c.RegisterDurationVar(124, time.Millisecond, t.Name())
-				},
-			)
+			require.Equal(t, 123*time.Second, v)
 		})
 		t.Run("[]string", func(t *testing.T) {
 			c := New()
 			v := c.RegisterStringSliceVar([]string{"a", "b"}, t.Name())
 			require.NotNil(t, v)
-			require.Equal(t, []string{"a", "b"}, *v)
+			require.Equal(t, []string{"a", "b"}, v)
 
 			c.Set(t.Name(), []string{"c", "d"})
-			require.Equal(t, []string{"a", "b"}, *v, "variable is not reloadable")
+			require.Equal(t, []string{"a", "b"}, v, "variable is not reloadable")
 		})
 		t.Run("map[string]interface{}", func(t *testing.T) {
 			c := New()
 			v := c.RegisterStringMapVar(map[string]interface{}{"a": 1, "b": 2}, t.Name())
 			require.NotNil(t, v)
-			require.Equal(t, map[string]interface{}{"a": 1, "b": 2}, *v)
+			require.Equal(t, map[string]interface{}{"a": 1, "b": 2}, v)
 
 			c.Set(t.Name(), map[string]interface{}{"c": 3, "d": 4})
-			require.Equal(t, map[string]interface{}{"a": 1, "b": 2}, *v, "variable is not reloadable")
+			require.Equal(t, map[string]interface{}{"a": 1, "b": 2}, v, "variable is not reloadable")
 		})
 	})
 	t.Run("reloadable", func(t *testing.T) {
@@ -309,6 +276,16 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), 10)
 			require.Equal(t, 10, v.Load(), "value should not change")
+
+			require.PanicsWithError(t,
+				"Detected misuse of config variable registered with different default values "+
+					"int:TestRegisterNewReloadableAPI/reloadable/int:5 - "+
+					"int:TestRegisterNewReloadableAPI/reloadable/int:10\n",
+				func() {
+					// changing just the valueScale also changes the default value
+					_ = c.RegisterReloadableIntVar(5, 2, t.Name())
+				},
+			)
 		})
 		t.Run("int64", func(t *testing.T) {
 			c := New()
@@ -320,6 +297,16 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), 10)
 			require.EqualValues(t, 10, v.Load(), "value should not change")
+
+			require.PanicsWithError(t,
+				"Detected misuse of config variable registered with different default values "+
+					"int64:TestRegisterNewReloadableAPI/reloadable/int64:5 - "+
+					"int64:TestRegisterNewReloadableAPI/reloadable/int64:10\n",
+				func() {
+					// changing just the valueScale also changes the default value
+					_ = c.RegisterReloadableInt64Var(5, 2, t.Name())
+				},
+			)
 		})
 		t.Run("bool", func(t *testing.T) {
 			c := New()
@@ -331,6 +318,15 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), false)
 			require.False(t, v.Load(), "value should not change")
+
+			require.PanicsWithError(t,
+				"Detected misuse of config variable registered with different default values "+
+					"bool:TestRegisterNewReloadableAPI/reloadable/bool:true - "+
+					"bool:TestRegisterNewReloadableAPI/reloadable/bool:false\n",
+				func() {
+					_ = c.RegisterReloadableBoolVar(false, t.Name())
+				},
+			)
 		})
 		t.Run("float64", func(t *testing.T) {
 			c := New()
@@ -342,6 +338,15 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), 4.567)
 			require.EqualValues(t, 4.567, v.Load(), "value should not change")
+
+			require.PanicsWithError(t,
+				"Detected misuse of config variable registered with different default values "+
+					"float64:TestRegisterNewReloadableAPI/reloadable/float64:0.123 - "+
+					"float64:TestRegisterNewReloadableAPI/reloadable/float64:0.1234\n",
+				func() {
+					_ = c.RegisterReloadableFloat64Var(0.1234, t.Name())
+				},
+			)
 		})
 		t.Run("string", func(t *testing.T) {
 			c := New()
@@ -353,10 +358,19 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), "bar")
 			require.EqualValues(t, "bar", v.Load(), "value should not change")
+
+			require.PanicsWithError(t,
+				"Detected misuse of config variable registered with different default values "+
+					"string:TestRegisterNewReloadableAPI/reloadable/string:foo - "+
+					"string:TestRegisterNewReloadableAPI/reloadable/string:qux\n",
+				func() {
+					_ = c.RegisterReloadableStringVar("qux", t.Name())
+				},
+			)
 		})
 		t.Run("duration", func(t *testing.T) {
 			c := New()
-			v := c.RegisterReloadableDurationVar(123, 1, t.Name())
+			v := c.RegisterReloadableDurationVar(123, time.Nanosecond, t.Name())
 			require.Equal(t, 123*time.Nanosecond, v.Load())
 
 			c.Set(t.Name(), 456*time.Millisecond)
@@ -370,7 +384,7 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 					"time.Duration:TestRegisterNewReloadableAPI/reloadable/duration:123ns - "+
 					"time.Duration:TestRegisterNewReloadableAPI/reloadable/duration:2m3s\n",
 				func() {
-					_ = c.RegisterDurationVar(123, time.Second, t.Name())
+					_ = c.RegisterReloadableDurationVar(123, time.Second, t.Name())
 				},
 			)
 		})
@@ -384,6 +398,15 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), []string{"c", "d"})
 			require.Equal(t, []string{"c", "d"}, v.Load(), "value should not change")
+
+			require.PanicsWithError(t,
+				"Detected misuse of config variable registered with different default values "+
+					"[]string:TestRegisterNewReloadableAPI/reloadable/[]string:[a b] - "+
+					"[]string:TestRegisterNewReloadableAPI/reloadable/[]string:[a b c]\n",
+				func() {
+					_ = c.RegisterReloadableStringSliceVar([]string{"a", "b", "c"}, t.Name())
+				},
+			)
 		})
 		t.Run("map[string]interface{}", func(t *testing.T) {
 			c := New()
@@ -395,6 +418,15 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			c.Set(t.Name(), map[string]interface{}{"c": 3, "d": 4})
 			require.Equal(t, map[string]interface{}{"c": 3, "d": 4}, v.Load(), "value should not change")
+
+			require.PanicsWithError(t,
+				"Detected misuse of config variable registered with different default values "+
+					"map[string]interface {}:TestRegisterNewReloadableAPI/reloadable/map[string]interface{}:map[a:1 b:2] - "+
+					"map[string]interface {}:TestRegisterNewReloadableAPI/reloadable/map[string]interface{}:map[a:2 b:1]\n",
+				func() {
+					_ = c.RegisterReloadableStringMapVar(map[string]interface{}{"a": 2, "b": 1}, t.Name())
+				},
+			)
 		})
 	})
 }
@@ -405,23 +437,23 @@ func TestGetOrCreatePointer(t *testing.T) {
 		dvs = make(map[string]string)
 		rwm sync.RWMutex
 	)
-	p1 := getOrCreatePointer(m, dvs, &rwm, 123, true, "foo", "bar")
+	p1 := getOrCreatePointer(m, dvs, &rwm, 123, "foo", "bar")
 	require.NotNil(t, p1)
 
-	p2 := getOrCreatePointer(m, dvs, &rwm, 123, true, "foo", "bar")
+	p2 := getOrCreatePointer(m, dvs, &rwm, 123, "foo", "bar")
 	require.True(t, p1 == p2)
 
-	p3 := getOrCreatePointer(m, dvs, &rwm, 123, true, "bar", "foo")
+	p3 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo")
 	require.True(t, p1 != p3)
 
-	p4 := getOrCreatePointer(m, dvs, &rwm, 123, true, "bar", "foo", "qux")
+	p4 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo", "qux")
 	require.True(t, p1 != p4)
 
 	require.PanicsWithError(t,
 		"Detected misuse of config variable registered with different default values "+
 			"int:bar,foo,qux:123 - int:bar,foo,qux:456\n",
 		func() {
-			getOrCreatePointer(m, dvs, &rwm, 456, true, "bar", "foo", "qux")
+			getOrCreatePointer(m, dvs, &rwm, 456, "bar", "foo", "qux")
 		},
 	)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -275,6 +275,16 @@ func TestAtomicHotReload(t *testing.T) {
 		c.Set(t.Name(), 456*time.Millisecond)
 		require.Equal(t, 456*time.Millisecond, v.Load())
 	})
+	t.Run("slice of strings", func(t *testing.T) {
+		var v Atomic[[]string]
+
+		c := New()
+		c.RegisterAtomicStringSliceVar([]string{"a", "b"}, &v, t.Name())
+		require.Equal(t, []string{"a", "b"}, v.Load())
+
+		c.Set(t.Name(), []string{"c", "d"})
+		require.Equal(t, []string{"c", "d"}, v.Load())
+	})
 }
 
 func TestAtomic(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -234,10 +233,8 @@ func TestAtomicHotReload(t *testing.T) {
 		require.EqualValues(t, 10, v.Load())
 	})
 	t.Run("bool", func(t *testing.T) {
-		var v Atomic[bool]
-
 		c := New()
-		c.RegisterAtomicBoolVar(true, &v, t.Name())
+		v := c.RegisterAtomicBoolVar(true, t.Name())
 		require.True(t, v.Load())
 
 		c.Set(t.Name(), false)
@@ -301,15 +298,15 @@ func TestAtomic(t *testing.T) {
 		v.store(123)
 		require.Equal(t, 123, v.Load())
 	})
-	t.Run("interface", func(t *testing.T) {
-		var v Atomic[error]
+	t.Run("nullable", func(t *testing.T) {
+		var v Atomic[[]string]
 		require.Nil(t, v.Load())
 
 		v.store(nil)
 		require.Nil(t, v.Load())
 
-		v.store(errors.New("some error"))
-		require.EqualError(t, v.Load(), "some error")
+		v.store([]string{"foo", "bar"})
+		require.Equal(t, v.Load(), []string{"foo", "bar"})
 
 		v.store(nil)
 		require.Nil(t, v.Load())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -213,6 +213,21 @@ func TestCheckAndHotReloadConfig(t *testing.T) {
 	})
 }
 
+func TestAtomicHotReload(t *testing.T) {
+	t.Run("atomic int", func(t *testing.T) {
+		var (
+			intValue Atomic[int]
+			key      = t.Name() + ".intValue"
+		)
+
+		c := New()
+		c.RegisterAtomicIntVar(0, &intValue, 1, key)
+		c.Set(key, 10)
+
+		require.Equal(t, 10, intValue.Load())
+	})
+}
+
 func TestConfigKeyToEnv(t *testing.T) {
 	expected := "RSERVER_KEY_VAR1_VAR2"
 	require.Equal(t, expected, ConfigKeyToEnv(DefaultEnvPrefix, "Key.Var1.Var2"))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -275,7 +275,7 @@ func TestAtomicHotReload(t *testing.T) {
 		c.Set(t.Name(), 456*time.Millisecond)
 		require.Equal(t, 456*time.Millisecond, v.Load())
 	})
-	t.Run("slice of strings", func(t *testing.T) {
+	t.Run("[]string", func(t *testing.T) {
 		var v Atomic[[]string]
 
 		c := New()
@@ -284,6 +284,16 @@ func TestAtomicHotReload(t *testing.T) {
 
 		c.Set(t.Name(), []string{"c", "d"})
 		require.Equal(t, []string{"c", "d"}, v.Load())
+	})
+	t.Run("map[string]interface{}", func(t *testing.T) {
+		var v Atomic[map[string]interface{}]
+
+		c := New()
+		c.RegisterAtomicStringMapVar(map[string]interface{}{"a": 1, "b": 2}, &v, t.Name())
+		require.Equal(t, map[string]interface{}{"a": 1, "b": 2}, v.Load())
+
+		c.Set(t.Name(), map[string]interface{}{"c": 3, "d": 4})
+		require.Equal(t, map[string]interface{}{"c": 3, "d": 4}, v.Load())
 	})
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -214,41 +214,41 @@ func TestCheckAndHotReloadConfig(t *testing.T) {
 	})
 }
 
-func TestRegisterNewReloadableAPI(t *testing.T) {
+func TestNewReloadableAPI(t *testing.T) {
 	t.Run("non reloadable", func(t *testing.T) {
 		t.Run("int", func(t *testing.T) {
 			c := New()
-			v := c.RegisterIntVar(5, 1, t.Name())
+			v := c.GetIntVar(5, 1, t.Name())
 			require.Equal(t, 5, v)
 		})
 		t.Run("int64", func(t *testing.T) {
 			c := New()
-			v := c.RegisterInt64Var(5, 1, t.Name())
+			v := c.GetInt64Var(5, 1, t.Name())
 			require.EqualValues(t, 5, v)
 		})
 		t.Run("bool", func(t *testing.T) {
 			c := New()
-			v := c.RegisterBoolVar(true, t.Name())
+			v := c.GetBoolVar(true, t.Name())
 			require.True(t, v)
 		})
 		t.Run("float64", func(t *testing.T) {
 			c := New()
-			v := c.RegisterFloat64Var(0.123, t.Name())
+			v := c.GetFloat64Var(0.123, t.Name())
 			require.EqualValues(t, 0.123, v)
 		})
 		t.Run("string", func(t *testing.T) {
 			c := New()
-			v := c.RegisterStringVar("foo", t.Name())
+			v := c.GetStringVar("foo", t.Name())
 			require.Equal(t, "foo", v)
 		})
 		t.Run("duration", func(t *testing.T) {
 			c := New()
-			v := c.RegisterDurationVar(123, time.Second, t.Name())
+			v := c.GetDurationVar(123, time.Second, t.Name())
 			require.Equal(t, 123*time.Second, v)
 		})
 		t.Run("[]string", func(t *testing.T) {
 			c := New()
-			v := c.RegisterStringSliceVar([]string{"a", "b"}, t.Name())
+			v := c.GetStringSliceVar([]string{"a", "b"}, t.Name())
 			require.NotNil(t, v)
 			require.Equal(t, []string{"a", "b"}, v)
 
@@ -257,7 +257,7 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 		})
 		t.Run("map[string]interface{}", func(t *testing.T) {
 			c := New()
-			v := c.RegisterStringMapVar(map[string]interface{}{"a": 1, "b": 2}, t.Name())
+			v := c.GetStringMapVar(map[string]interface{}{"a": 1, "b": 2}, t.Name())
 			require.NotNil(t, v)
 			require.Equal(t, map[string]interface{}{"a": 1, "b": 2}, v)
 
@@ -268,7 +268,7 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 	t.Run("reloadable", func(t *testing.T) {
 		t.Run("int", func(t *testing.T) {
 			c := New()
-			v := c.RegisterReloadableIntVar(5, 1, t.Name())
+			v := c.GetReloadableIntVar(5, 1, t.Name())
 			require.Equal(t, 5, v.Load())
 
 			c.Set(t.Name(), 10)
@@ -279,17 +279,17 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			require.PanicsWithError(t,
 				"Detected misuse of config variable registered with different default values "+
-					"int:TestRegisterNewReloadableAPI/reloadable/int:5 - "+
-					"int:TestRegisterNewReloadableAPI/reloadable/int:10\n",
+					"int:TestNewReloadableAPI/reloadable/int:5 - "+
+					"int:TestNewReloadableAPI/reloadable/int:10\n",
 				func() {
 					// changing just the valueScale also changes the default value
-					_ = c.RegisterReloadableIntVar(5, 2, t.Name())
+					_ = c.GetReloadableIntVar(5, 2, t.Name())
 				},
 			)
 		})
 		t.Run("int64", func(t *testing.T) {
 			c := New()
-			v := c.RegisterReloadableInt64Var(5, 1, t.Name())
+			v := c.GetReloadableInt64Var(5, 1, t.Name())
 			require.EqualValues(t, 5, v.Load())
 
 			c.Set(t.Name(), 10)
@@ -300,17 +300,17 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			require.PanicsWithError(t,
 				"Detected misuse of config variable registered with different default values "+
-					"int64:TestRegisterNewReloadableAPI/reloadable/int64:5 - "+
-					"int64:TestRegisterNewReloadableAPI/reloadable/int64:10\n",
+					"int64:TestNewReloadableAPI/reloadable/int64:5 - "+
+					"int64:TestNewReloadableAPI/reloadable/int64:10\n",
 				func() {
 					// changing just the valueScale also changes the default value
-					_ = c.RegisterReloadableInt64Var(5, 2, t.Name())
+					_ = c.GetReloadableInt64Var(5, 2, t.Name())
 				},
 			)
 		})
 		t.Run("bool", func(t *testing.T) {
 			c := New()
-			v := c.RegisterReloadableBoolVar(true, t.Name())
+			v := c.GetReloadableBoolVar(true, t.Name())
 			require.True(t, v.Load())
 
 			c.Set(t.Name(), false)
@@ -321,16 +321,16 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			require.PanicsWithError(t,
 				"Detected misuse of config variable registered with different default values "+
-					"bool:TestRegisterNewReloadableAPI/reloadable/bool:true - "+
-					"bool:TestRegisterNewReloadableAPI/reloadable/bool:false\n",
+					"bool:TestNewReloadableAPI/reloadable/bool:true - "+
+					"bool:TestNewReloadableAPI/reloadable/bool:false\n",
 				func() {
-					_ = c.RegisterReloadableBoolVar(false, t.Name())
+					_ = c.GetReloadableBoolVar(false, t.Name())
 				},
 			)
 		})
 		t.Run("float64", func(t *testing.T) {
 			c := New()
-			v := c.RegisterReloadableFloat64Var(0.123, t.Name())
+			v := c.GetReloadableFloat64Var(0.123, t.Name())
 			require.EqualValues(t, 0.123, v.Load())
 
 			c.Set(t.Name(), 4.567)
@@ -341,16 +341,16 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			require.PanicsWithError(t,
 				"Detected misuse of config variable registered with different default values "+
-					"float64:TestRegisterNewReloadableAPI/reloadable/float64:0.123 - "+
-					"float64:TestRegisterNewReloadableAPI/reloadable/float64:0.1234\n",
+					"float64:TestNewReloadableAPI/reloadable/float64:0.123 - "+
+					"float64:TestNewReloadableAPI/reloadable/float64:0.1234\n",
 				func() {
-					_ = c.RegisterReloadableFloat64Var(0.1234, t.Name())
+					_ = c.GetReloadableFloat64Var(0.1234, t.Name())
 				},
 			)
 		})
 		t.Run("string", func(t *testing.T) {
 			c := New()
-			v := c.RegisterReloadableStringVar("foo", t.Name())
+			v := c.GetReloadableStringVar("foo", t.Name())
 			require.Equal(t, "foo", v.Load())
 
 			c.Set(t.Name(), "bar")
@@ -361,16 +361,16 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			require.PanicsWithError(t,
 				"Detected misuse of config variable registered with different default values "+
-					"string:TestRegisterNewReloadableAPI/reloadable/string:foo - "+
-					"string:TestRegisterNewReloadableAPI/reloadable/string:qux\n",
+					"string:TestNewReloadableAPI/reloadable/string:foo - "+
+					"string:TestNewReloadableAPI/reloadable/string:qux\n",
 				func() {
-					_ = c.RegisterReloadableStringVar("qux", t.Name())
+					_ = c.GetReloadableStringVar("qux", t.Name())
 				},
 			)
 		})
 		t.Run("duration", func(t *testing.T) {
 			c := New()
-			v := c.RegisterReloadableDurationVar(123, time.Nanosecond, t.Name())
+			v := c.GetReloadableDurationVar(123, time.Nanosecond, t.Name())
 			require.Equal(t, 123*time.Nanosecond, v.Load())
 
 			c.Set(t.Name(), 456*time.Millisecond)
@@ -381,16 +381,16 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			require.PanicsWithError(t,
 				"Detected misuse of config variable registered with different default values "+
-					"time.Duration:TestRegisterNewReloadableAPI/reloadable/duration:123ns - "+
-					"time.Duration:TestRegisterNewReloadableAPI/reloadable/duration:2m3s\n",
+					"time.Duration:TestNewReloadableAPI/reloadable/duration:123ns - "+
+					"time.Duration:TestNewReloadableAPI/reloadable/duration:2m3s\n",
 				func() {
-					_ = c.RegisterReloadableDurationVar(123, time.Second, t.Name())
+					_ = c.GetReloadableDurationVar(123, time.Second, t.Name())
 				},
 			)
 		})
 		t.Run("[]string", func(t *testing.T) {
 			c := New()
-			v := c.RegisterReloadableStringSliceVar([]string{"a", "b"}, t.Name())
+			v := c.GetReloadableStringSliceVar([]string{"a", "b"}, t.Name())
 			require.Equal(t, []string{"a", "b"}, v.Load())
 
 			c.Set(t.Name(), []string{"c", "d"})
@@ -401,16 +401,16 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			require.PanicsWithError(t,
 				"Detected misuse of config variable registered with different default values "+
-					"[]string:TestRegisterNewReloadableAPI/reloadable/[]string:[a b] - "+
-					"[]string:TestRegisterNewReloadableAPI/reloadable/[]string:[a b c]\n",
+					"[]string:TestNewReloadableAPI/reloadable/[]string:[a b] - "+
+					"[]string:TestNewReloadableAPI/reloadable/[]string:[a b c]\n",
 				func() {
-					_ = c.RegisterReloadableStringSliceVar([]string{"a", "b", "c"}, t.Name())
+					_ = c.GetReloadableStringSliceVar([]string{"a", "b", "c"}, t.Name())
 				},
 			)
 		})
 		t.Run("map[string]interface{}", func(t *testing.T) {
 			c := New()
-			v := c.RegisterReloadableStringMapVar(map[string]interface{}{"a": 1, "b": 2}, t.Name())
+			v := c.GetReloadableStringMapVar(map[string]interface{}{"a": 1, "b": 2}, t.Name())
 			require.Equal(t, map[string]interface{}{"a": 1, "b": 2}, v.Load())
 
 			c.Set(t.Name(), map[string]interface{}{"c": 3, "d": 4})
@@ -421,10 +421,10 @@ func TestRegisterNewReloadableAPI(t *testing.T) {
 
 			require.PanicsWithError(t,
 				"Detected misuse of config variable registered with different default values "+
-					"map[string]interface {}:TestRegisterNewReloadableAPI/reloadable/map[string]interface{}:map[a:1 b:2] - "+
-					"map[string]interface {}:TestRegisterNewReloadableAPI/reloadable/map[string]interface{}:map[a:2 b:1]\n",
+					"map[string]interface {}:TestNewReloadableAPI/reloadable/map[string]interface{}:map[a:1 b:2] - "+
+					"map[string]interface {}:TestNewReloadableAPI/reloadable/map[string]interface{}:map[a:2 b:1]\n",
 				func() {
-					_ = c.RegisterReloadableStringMapVar(map[string]interface{}{"a": 2, "b": 1}, t.Name())
+					_ = c.GetReloadableStringMapVar(map[string]interface{}{"a": 2, "b": 1}, t.Name())
 				},
 			)
 		})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -216,10 +216,8 @@ func TestCheckAndHotReloadConfig(t *testing.T) {
 
 func TestAtomicHotReload(t *testing.T) {
 	t.Run("int", func(t *testing.T) {
-		var v Atomic[int]
-
 		c := New()
-		c.RegisterAtomicIntVar(5, &v, 1, t.Name())
+		v := c.RegisterAtomicIntVar(5, 1, t.Name())
 		require.Equal(t, 5, v.Load())
 
 		c.Set(t.Name(), 10)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -263,20 +263,16 @@ func TestAtomicHotReload(t *testing.T) {
 		require.Equal(t, 456*time.Millisecond, v.Load())
 	})
 	t.Run("[]string", func(t *testing.T) {
-		var v Atomic[[]string]
-
 		c := New()
-		c.RegisterAtomicStringSliceVar([]string{"a", "b"}, &v, t.Name())
+		v := c.RegisterAtomicStringSliceVar([]string{"a", "b"}, t.Name())
 		require.Equal(t, []string{"a", "b"}, v.Load())
 
 		c.Set(t.Name(), []string{"c", "d"})
 		require.Equal(t, []string{"c", "d"}, v.Load())
 	})
 	t.Run("map[string]interface{}", func(t *testing.T) {
-		var v Atomic[map[string]interface{}]
-
 		c := New()
-		c.RegisterAtomicStringMapVar(map[string]interface{}{"a": 1, "b": 2}, &v, t.Name())
+		v := c.RegisterAtomicStringMapVar(map[string]interface{}{"a": 1, "b": 2}, t.Name())
 		require.Equal(t, map[string]interface{}{"a": 1, "b": 2}, v.Load())
 
 		c.Set(t.Name(), map[string]interface{}{"c": 3, "d": 4})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -223,10 +223,8 @@ func TestAtomicHotReload(t *testing.T) {
 		require.Equal(t, 10, v.Load())
 	})
 	t.Run("int64", func(t *testing.T) {
-		var v Atomic[int64]
-
 		c := New()
-		c.RegisterAtomicInt64Var(5, &v, 1, t.Name())
+		v := c.RegisterAtomicInt64Var(5, 1, t.Name())
 		require.EqualValues(t, 5, v.Load())
 
 		c.Set(t.Name(), 10)
@@ -241,30 +239,24 @@ func TestAtomicHotReload(t *testing.T) {
 		require.False(t, v.Load())
 	})
 	t.Run("float64", func(t *testing.T) {
-		var v Atomic[float64]
-
 		c := New()
-		c.RegisterAtomicFloat64Var(0.123, &v, t.Name())
+		v := c.RegisterAtomicFloat64Var(0.123, t.Name())
 		require.EqualValues(t, 0.123, v.Load())
 
 		c.Set(t.Name(), 4.567)
 		require.EqualValues(t, 4.567, v.Load())
 	})
 	t.Run("string", func(t *testing.T) {
-		var v Atomic[string]
-
 		c := New()
-		c.RegisterAtomicStringVar("foo", &v, t.Name())
+		v := c.RegisterAtomicStringVar("foo", t.Name())
 		require.Equal(t, "foo", v.Load())
 
 		c.Set(t.Name(), "bar")
 		require.EqualValues(t, "bar", v.Load())
 	})
 	t.Run("duration", func(t *testing.T) {
-		var v Atomic[time.Duration]
-
 		c := New()
-		c.RegisterAtomicDurationVar(123, &v, 1, t.Name())
+		v := c.RegisterAtomicDurationVar(123, 1, t.Name())
 		require.Equal(t, 123*time.Nanosecond, v.Load())
 
 		c.Set(t.Name(), 456*time.Millisecond)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -214,17 +214,23 @@ func TestCheckAndHotReloadConfig(t *testing.T) {
 }
 
 func TestAtomicHotReload(t *testing.T) {
-	t.Run("atomic int", func(t *testing.T) {
-		var (
-			intValue Atomic[int]
-			key      = t.Name() + ".intValue"
-		)
+	t.Run("int", func(t *testing.T) {
+		var v Atomic[int]
 
 		c := New()
-		c.RegisterAtomicIntVar(0, &intValue, 1, key)
-		c.Set(key, 10)
+		c.RegisterAtomicIntVar(0, &v, 1, t.Name())
+		c.Set(t.Name(), 10)
 
-		require.Equal(t, 10, intValue.Load())
+		require.Equal(t, 10, v.Load())
+	})
+	t.Run("duration", func(t *testing.T) {
+		var v Atomic[time.Duration]
+
+		c := New()
+		c.RegisterAtomicDurationVar(0, &v, 1, t.Name())
+		c.Set(t.Name(), 123*time.Millisecond)
+
+		require.Equal(t, 123*time.Millisecond, v.Load())
 	})
 }
 

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -15,7 +15,7 @@ func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool,
 
 // RegisterIntVar registers a not hot-reloadable int config variable
 // WARNING: a different order of keys will result in a different variable
-func RegisterIntVar(defaultValue int, valueScale int, orderedKeys ...string) *int {
+func RegisterIntVar(defaultValue, valueScale int, orderedKeys ...string) *int {
 	return Default.RegisterIntVar(defaultValue, valueScale, orderedKeys...)
 }
 
@@ -38,7 +38,7 @@ func (c *Config) RegisterIntConfigVariable(
 
 // RegisterIntVar registers a not hot-reloadable int config variable
 // WARNING: a different order of keys will result in a different variable
-func (c *Config) RegisterIntVar(defaultValue int, valueScale int, orderedKeys ...string) *int {
+func (c *Config) RegisterIntVar(defaultValue, valueScale int, orderedKeys ...string) *int {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*int)
 	c.registerIntVar(defaultValue, ptr, false, valueScale, func(v int) {
 		*ptr = v
@@ -241,7 +241,7 @@ func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable
 
 // RegisterInt64Var registers a not hot-reloadable int64 config variable
 // WARNING: a different order of keys will result in a different variable
-func RegisterInt64Var(defaultValue int64, valueScale int64, orderedKeys ...string) *int64 {
+func RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *int64 {
 	return Default.RegisterInt64Var(defaultValue, valueScale, orderedKeys...)
 }
 
@@ -264,7 +264,7 @@ func (c *Config) RegisterInt64ConfigVariable(
 
 // RegisterInt64Var registers a not hot-reloadable int64 config variable
 // WARNING: a different order of keys will result in a different variable
-func (c *Config) RegisterInt64Var(defaultValue int64, valueScale int64, orderedKeys ...string) *int64 {
+func (c *Config) RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *int64 {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*int64)
 	c.registerInt64Var(defaultValue, ptr, false, valueScale, func(v int64) {
 		*ptr = v

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -7,6 +7,7 @@ import (
 )
 
 // RegisterIntConfigVariable registers int config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -16,6 +17,7 @@ func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool,
 }
 
 // RegisterIntVar registers a not hot-reloadable int config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterIntVar(defaultValue, valueScale int, orderedKeys ...string) int {
@@ -23,6 +25,7 @@ func RegisterIntVar(defaultValue, valueScale int, orderedKeys ...string) int {
 }
 
 // RegisterReloadableIntVar registers a hot-reloadable int config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
@@ -30,6 +33,7 @@ func RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...strin
 }
 
 // RegisterIntConfigVariable registers int config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -43,6 +47,7 @@ func (c *Config) RegisterIntConfigVariable(
 }
 
 // RegisterIntVar registers a not hot-reloadable int config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterIntVar(defaultValue, valueScale int, orderedKeys ...string) int {
@@ -54,6 +59,7 @@ func (c *Config) RegisterIntVar(defaultValue, valueScale int, orderedKeys ...str
 }
 
 // RegisterReloadableIntVar registers a hot-reloadable int config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
@@ -94,6 +100,7 @@ func (c *Config) registerIntVar(
 }
 
 // RegisterBoolConfigVariable registers bool config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -103,6 +110,7 @@ func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bo
 }
 
 // RegisterBoolVar registers a not hot-reloadable bool config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterBoolVar(defaultValue bool, orderedKeys ...string) bool {
@@ -110,6 +118,7 @@ func RegisterBoolVar(defaultValue bool, orderedKeys ...string) bool {
 }
 
 // RegisterReloadableBoolVar registers a hot-reloadable bool config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
@@ -117,6 +126,7 @@ func RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reload
 }
 
 // RegisterBoolConfigVariable registers bool config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -128,6 +138,7 @@ func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotR
 }
 
 // RegisterBoolVar registers a not hot-reloadable bool config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterBoolVar(defaultValue bool, orderedKeys ...string) bool {
@@ -139,6 +150,7 @@ func (c *Config) RegisterBoolVar(defaultValue bool, orderedKeys ...string) bool 
 }
 
 // RegisterReloadableBoolVar registers a hot-reloadable bool config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
@@ -177,6 +189,7 @@ func (c *Config) registerBoolVar(defaultValue bool, ptr any, isHotReloadable boo
 }
 
 // RegisterFloat64ConfigVariable registers float64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -186,6 +199,7 @@ func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotRelo
 }
 
 // RegisterFloat64Var registers a not hot-reloadable float64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterFloat64Var(defaultValue float64, orderedKeys ...string) float64 {
@@ -193,6 +207,7 @@ func RegisterFloat64Var(defaultValue float64, orderedKeys ...string) float64 {
 }
 
 // RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
@@ -200,6 +215,7 @@ func RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *
 }
 
 // RegisterFloat64ConfigVariable registers float64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -213,6 +229,7 @@ func (c *Config) RegisterFloat64ConfigVariable(
 }
 
 // RegisterFloat64Var registers a not hot-reloadable float64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterFloat64Var(defaultValue float64, orderedKeys ...string) float64 {
@@ -224,6 +241,7 @@ func (c *Config) RegisterFloat64Var(defaultValue float64, orderedKeys ...string)
 }
 
 // RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
@@ -265,6 +283,7 @@ func (c *Config) registerFloat64Var(
 }
 
 // RegisterInt64ConfigVariable registers int64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -274,6 +293,7 @@ func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable
 }
 
 // RegisterInt64Var registers a not hot-reloadable int64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ...string) int64 {
@@ -281,6 +301,7 @@ func RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ...string) int
 }
 
 // RegisterReloadableInt64Var registers a hot-reloadable int64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
@@ -288,6 +309,7 @@ func RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...s
 }
 
 // RegisterInt64ConfigVariable registers int64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -301,6 +323,7 @@ func (c *Config) RegisterInt64ConfigVariable(
 }
 
 // RegisterInt64Var registers a not hot-reloadable int64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ...string) int64 {
@@ -312,6 +335,7 @@ func (c *Config) RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ..
 }
 
 // RegisterReloadableInt64Var registers a not hot-reloadable int64 config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
@@ -353,6 +377,7 @@ func (c *Config) registerInt64Var(
 }
 
 // RegisterDurationConfigVariable registers duration config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -364,6 +389,7 @@ func RegisterDurationConfigVariable(
 }
 
 // RegisterDurationVar registers a not hot-reloadable duration config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterDurationVar(
@@ -373,6 +399,7 @@ func RegisterDurationVar(
 }
 
 // RegisterReloadableDurationVar registers a not hot-reloadable duration config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableDurationVar(defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string) *Reloadable[time.Duration] {
@@ -380,6 +407,7 @@ func RegisterReloadableDurationVar(defaultValueInTimescaleUnits int64, timeScale
 }
 
 // RegisterDurationConfigVariable registers duration config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -393,6 +421,7 @@ func (c *Config) RegisterDurationConfigVariable(
 }
 
 // RegisterDurationVar registers a not hot-reloadable duration config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterDurationVar(
@@ -406,6 +435,7 @@ func (c *Config) RegisterDurationVar(
 }
 
 // RegisterReloadableDurationVar registers a hot-reloadable duration config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableDurationVar(
@@ -450,6 +480,7 @@ func (c *Config) registerDurationVar(
 }
 
 // RegisterStringConfigVariable registers string config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -459,6 +490,7 @@ func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloada
 }
 
 // RegisterStringVar registers a not hot-reloadable string config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterStringVar(defaultValue string, orderedKeys ...string) string {
@@ -466,6 +498,7 @@ func RegisterStringVar(defaultValue string, orderedKeys ...string) string {
 }
 
 // RegisterReloadableStringVar registers a hot-reloadable string config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
@@ -473,6 +506,7 @@ func RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Re
 }
 
 // RegisterStringConfigVariable registers string config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -486,6 +520,7 @@ func (c *Config) RegisterStringConfigVariable(
 }
 
 // RegisterStringVar registers a not hot-reloadable string config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterStringVar(defaultValue string, orderedKeys ...string) string {
@@ -497,6 +532,7 @@ func (c *Config) RegisterStringVar(defaultValue string, orderedKeys ...string) s
 }
 
 // RegisterReloadableStringVar registers a hot-reloadable string config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
@@ -536,6 +572,7 @@ func (c *Config) registerStringVar(
 }
 
 // RegisterStringSliceConfigVariable registers string slice config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -545,6 +582,7 @@ func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isH
 }
 
 // RegisterStringSliceVar registers a not hot-reloadable string slice config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterStringSliceVar(defaultValue []string, orderedKeys ...string) []string {
@@ -552,6 +590,7 @@ func RegisterStringSliceVar(defaultValue []string, orderedKeys ...string) []stri
 }
 
 // RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
@@ -559,6 +598,7 @@ func RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...stri
 }
 
 // RegisterStringSliceConfigVariable registers string slice config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -572,6 +612,7 @@ func (c *Config) RegisterStringSliceConfigVariable(
 }
 
 // RegisterStringSliceVar registers a not hot-reloadable string slice config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterStringSliceVar(defaultValue []string, orderedKeys ...string) []string {
@@ -583,6 +624,7 @@ func (c *Config) RegisterStringSliceVar(defaultValue []string, orderedKeys ...st
 }
 
 // RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
@@ -622,6 +664,7 @@ func (c *Config) registerStringSliceVar(
 }
 
 // RegisterStringMapConfigVariable registers string map config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -633,6 +676,7 @@ func RegisterStringMapConfigVariable(
 }
 
 // RegisterStringMapVar registers a not hot-reloadable string map config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterStringMapVar(defaultValue map[string]interface{}, orderedKeys ...string) map[string]interface{} {
@@ -640,6 +684,7 @@ func RegisterStringMapVar(defaultValue map[string]interface{}, orderedKeys ...st
 }
 
 // RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableStringMapVar(
@@ -649,6 +694,7 @@ func RegisterReloadableStringMapVar(
 }
 
 // RegisterStringMapConfigVariable registers string map config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
@@ -662,6 +708,7 @@ func (c *Config) RegisterStringMapConfigVariable(
 }
 
 // RegisterStringMapVar registers a not hot-reloadable string map config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterStringMapVar(
@@ -675,6 +722,7 @@ func (c *Config) RegisterStringMapVar(
 }
 
 // RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
+//
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableStringMapVar(

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -41,7 +41,7 @@ func (c *Config) RegisterIntVar(defaultValue int, ptr *int, valueScale int, keys
 // RegisterAtomicIntVar registers a hot-reloadable int config variable
 // Copy of RegisterIntConfigVariable, but with a way to avoid data races for hot reloadable config variables
 func (c *Config) RegisterAtomicIntVar(defaultValue, valueScale int, keys ...string) *Atomic[int] {
-	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerIntVar(defaultValue, ptr, true, valueScale, func(v int) {
 		ptr.store(v)
 	}, keys...)
@@ -108,7 +108,7 @@ func (c *Config) RegisterBoolVar(defaultValue bool, ptr *bool, keys ...string) {
 
 // RegisterAtomicBoolVar registers a hot-reloadable bool config variable
 func (c *Config) RegisterAtomicBoolVar(defaultValue bool, keys ...string) *Atomic[bool] {
-	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerBoolVar(defaultValue, ptr, true, func(v bool) {
 		ptr.store(v)
 	}, keys...)
@@ -173,7 +173,7 @@ func (c *Config) RegisterFloat64Var(defaultValue float64, ptr *float64, keys ...
 
 // RegisterAtomicFloat64Var registers a hot-reloadable float64 config variable
 func (c *Config) RegisterAtomicFloat64Var(defaultValue float64, keys ...string) *Atomic[float64] {
-	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerFloat64Var(defaultValue, ptr, true, func(v float64) {
 		ptr.store(v)
 	}, keys...)
@@ -243,7 +243,7 @@ func (c *Config) RegisterInt64Var(defaultValue int64, ptr *int64, valueScale int
 
 // RegisterAtomicInt64Var registers a not hot-reloadable int64 config variable
 func (c *Config) RegisterAtomicInt64Var(defaultValue, valueScale int64, keys ...string) *Atomic[int64] {
-	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerInt64Var(defaultValue, ptr, true, valueScale, func(v int64) {
 		ptr.store(v)
 	}, keys...)
@@ -322,7 +322,7 @@ func (c *Config) RegisterAtomicDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, keys ...string,
 ) *Atomic[time.Duration] {
 	ptr := getOrCreatePointer(
-		&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, time.Duration(defaultValueInTimescaleUnits), keys...,
+		c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, time.Duration(defaultValueInTimescaleUnits), keys...,
 	)
 	c.registerDurationVar(defaultValueInTimescaleUnits, ptr, true, timeScale, func(v time.Duration) {
 		ptr.store(v)
@@ -391,7 +391,7 @@ func (c *Config) RegisterStringVar(defaultValue string, ptr *string, keys ...str
 
 // RegisterAtomicStringVar registers a hot-reloadable string config variable
 func (c *Config) RegisterAtomicStringVar(defaultValue string, keys ...string) *Atomic[string] {
-	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerStringVar(defaultValue, ptr, true, func(v string) {
 		ptr.store(v)
 	}, keys...)
@@ -457,7 +457,7 @@ func (c *Config) RegisterStringSliceVar(defaultValue []string, ptr *[]string, ke
 
 // RegisterAtomicStringSliceVar registers a hot-reloadable string slice config variable
 func (c *Config) RegisterAtomicStringSliceVar(defaultValue []string, keys ...string) *Atomic[[]string] {
-	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerStringSliceVar(defaultValue, ptr, true, func(v []string) {
 		ptr.store(v)
 	}, keys...)
@@ -535,7 +535,7 @@ func (c *Config) RegisterStringMapVar(
 func (c *Config) RegisterAtomicStringMapVar(
 	defaultValue map[string]interface{}, keys ...string,
 ) *Atomic[map[string]interface{}] {
-	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerStringMapVar(defaultValue, ptr, true, func(v map[string]interface{}) {
 		ptr.store(v)
 	}, keys...)

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -42,7 +42,7 @@ func (c *Config) RegisterIntVar(defaultValue int, ptr *int, valueScale int, keys
 // Copy of RegisterIntConfigVariable, but with a way to avoid data races for hot reloadable config variables
 func (c *Config) RegisterAtomicIntVar(defaultValue int, ptr *Atomic[int], valueScale int, keys ...string) {
 	c.registerIntVar(defaultValue, ptr, true, valueScale, func(v int) {
-		ptr.Store(v)
+		ptr.store(v)
 	}, keys...)
 }
 
@@ -107,7 +107,7 @@ func (c *Config) RegisterBoolVar(defaultValue bool, ptr *bool, keys ...string) {
 // RegisterAtomicBoolVar registers a hot-reloadable bool config variable
 func (c *Config) RegisterAtomicBoolVar(defaultValue bool, ptr *Atomic[bool], keys ...string) {
 	c.registerBoolVar(defaultValue, ptr, true, func(v bool) {
-		ptr.Store(v)
+		ptr.store(v)
 	}, keys...)
 }
 
@@ -170,7 +170,7 @@ func (c *Config) RegisterFloat64Var(defaultValue float64, ptr *float64, keys ...
 // RegisterAtomicFloat64Var registers a hot-reloadable float64 config variable
 func (c *Config) RegisterAtomicFloat64Var(defaultValue float64, ptr *Atomic[float64], keys ...string) {
 	c.registerFloat64Var(defaultValue, ptr, true, func(v float64) {
-		ptr.Store(v)
+		ptr.store(v)
 	}, keys...)
 }
 
@@ -238,7 +238,7 @@ func (c *Config) RegisterInt64Var(defaultValue int64, ptr *int64, valueScale int
 // RegisterAtomicInt64Var registers a not hot-reloadable int64 config variable
 func (c *Config) RegisterAtomicInt64Var(defaultValue int64, ptr *Atomic[int64], valueScale int64, keys ...string) {
 	c.registerInt64Var(defaultValue, ptr, true, valueScale, func(v int64) {
-		ptr.Store(v)
+		ptr.store(v)
 	}, keys...)
 }
 
@@ -316,7 +316,7 @@ func (c *Config) RegisterAtomicDurationVar(
 	defaultValueInTimescaleUnits int64, ptr *Atomic[time.Duration], timeScale time.Duration, keys ...string,
 ) {
 	c.registerDurationVar(defaultValueInTimescaleUnits, ptr, true, timeScale, func(v time.Duration) {
-		ptr.Store(v)
+		ptr.store(v)
 	}, keys...)
 }
 
@@ -382,7 +382,7 @@ func (c *Config) RegisterStringVar(defaultValue string, ptr *string, keys ...str
 // RegisterAtomicStringVar registers a hot-reloadable string config variable
 func (c *Config) RegisterAtomicStringVar(defaultValue string, ptr *Atomic[string], keys ...string) {
 	c.registerStringVar(defaultValue, ptr, true, func(v string) {
-		ptr.Store(v)
+		ptr.store(v)
 	}, keys...)
 }
 
@@ -446,7 +446,7 @@ func (c *Config) RegisterStringSliceVar(defaultValue []string, ptr *[]string, ke
 // RegisterAtomicStringSliceVar registers a hot-reloadable string slice config variable
 func (c *Config) RegisterAtomicStringSliceVar(defaultValue []string, ptr *Atomic[[]string], keys ...string) {
 	c.registerStringSliceVar(defaultValue, ptr, true, func(v []string) {
-		ptr.Store(v)
+		ptr.store(v)
 	}, keys...)
 }
 
@@ -522,7 +522,7 @@ func (c *Config) RegisterAtomicStringMapVar(
 	defaultValue map[string]interface{}, ptr *Atomic[map[string]interface{}], keys ...string,
 ) {
 	c.registerStringMapVar(defaultValue, ptr, true, func(v map[string]interface{}) {
-		ptr.Store(v)
+		ptr.store(v)
 	}, keys...)
 }
 
@@ -573,8 +573,7 @@ func (a *Atomic[T]) Load() T {
 	return v
 }
 
-// Store should be used to write a value without worrying about data races
-func (a *Atomic[T]) Store(v T) {
+func (a *Atomic[T]) store(v T) {
 	a.lock.Lock()
 	a.value = v
 	a.lock.Unlock()

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -23,7 +23,9 @@ func RegisterAtomicIntVar(defaultValue int, ptr *Atomic[int], valueScale int, ke
 
 // RegisterIntConfigVariable registers int config variable
 // Deprecated: use RegisterIntVar or RegisterAtomicIntVar instead
-func (c *Config) RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
+func (c *Config) RegisterIntConfigVariable(
+	defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string,
+) {
 	c.registerIntVar(defaultValue, ptr, isHotReloadable, valueScale, func(v int) {
 		*ptr = v
 	}, keys...)
@@ -44,7 +46,9 @@ func (c *Config) RegisterAtomicIntVar(defaultValue int, ptr *Atomic[int], valueS
 	}, keys...)
 }
 
-func (c *Config) registerIntVar(defaultValue int, ptr any, isHotReloadable bool, valueScale int, store func(int), keys ...string) {
+func (c *Config) registerIntVar(
+	defaultValue int, ptr any, isHotReloadable bool, valueScale int, store func(int), keys ...string,
+) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
 	c.hotReloadableConfigLock.Lock()
@@ -138,6 +142,16 @@ func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotRelo
 	Default.RegisterFloat64ConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
 
+// RegisterFloat64Var registers float64 config variable
+func RegisterFloat64Var(defaultValue float64, ptr *float64, keys ...string) {
+	Default.RegisterFloat64Var(defaultValue, ptr, keys...)
+}
+
+// RegisterAtomicFloat64Var registers float64 config variable
+func RegisterAtomicFloat64Var(defaultValue float64, ptr *Atomic[float64], keys ...string) {
+	Default.RegisterAtomicFloat64Var(defaultValue, ptr, keys...)
+}
+
 // RegisterFloat64ConfigVariable registers float64 config variable
 // Deprecated: use RegisterFloat64Var or RegisterAtomicFloat64Var instead
 func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, keys ...string) {
@@ -161,7 +175,7 @@ func (c *Config) RegisterAtomicFloat64Var(defaultValue float64, ptr *Atomic[floa
 }
 
 func (c *Config) registerFloat64Var(
-	defaultValue float64, ptr any, isHotReloadable bool, store func(v float64), keys ...string,
+	defaultValue float64, ptr any, isHotReloadable bool, store func(float64), keys ...string,
 ) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
@@ -189,12 +203,48 @@ func (c *Config) registerFloat64Var(
 }
 
 // RegisterInt64ConfigVariable registers int64 config variable
+// Deprecated: use RegisterInt64Var or RegisterAtomicInt64Var instead
 func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string) {
 	Default.RegisterInt64ConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
 }
 
+// RegisterInt64Var registers a not hot-reloadable int64 config variable
+func RegisterInt64Var(defaultValue int64, ptr *int64, valueScale int64, keys ...string) {
+	Default.RegisterInt64Var(defaultValue, ptr, valueScale, keys...)
+}
+
+// RegisterAtomicInt64Var registers a hot-reloadable int64 config variable
+func RegisterAtomicInt64Var(defaultValue int64, ptr *Atomic[int64], valueScale int64, keys ...string) {
+	Default.RegisterAtomicInt64Var(defaultValue, ptr, valueScale, keys...)
+}
+
 // RegisterInt64ConfigVariable registers int64 config variable
-func (c *Config) RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string) {
+// Deprecated: use RegisterInt64Var or RegisterAtomicInt64Var instead
+func (c *Config) RegisterInt64ConfigVariable(
+	defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string,
+) {
+	c.registerInt64Var(defaultValue, ptr, isHotReloadable, valueScale, func(v int64) {
+		*ptr = v
+	}, keys...)
+}
+
+// RegisterInt64Var registers a not hot-reloadable int64 config variable
+func (c *Config) RegisterInt64Var(defaultValue int64, ptr *int64, valueScale int64, keys ...string) {
+	c.registerInt64Var(defaultValue, ptr, false, valueScale, func(v int64) {
+		*ptr = v
+	}, keys...)
+}
+
+// RegisterAtomicInt64Var registers a not hot-reloadable int64 config variable
+func (c *Config) RegisterAtomicInt64Var(defaultValue int64, ptr *Atomic[int64], valueScale int64, keys ...string) {
+	c.registerInt64Var(defaultValue, ptr, true, valueScale, func(v int64) {
+		ptr.Store(v)
+	}, keys...)
+}
+
+func (c *Config) registerInt64Var(
+	defaultValue int64, ptr any, isHotReloadable bool, valueScale int64, store func(int64), keys ...string,
+) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
 	c.hotReloadableConfigLock.Lock()
@@ -213,26 +263,32 @@ func (c *Config) RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isH
 	for _, key := range keys {
 		c.bindEnv(key)
 		if c.IsSet(key) {
-			*ptr = c.GetInt64(key, defaultValue) * valueScale
+			store(c.GetInt64(key, defaultValue) * valueScale)
 			return
 		}
 	}
-	*ptr = defaultValue * valueScale
+	store(defaultValue * valueScale)
 }
 
 // RegisterDurationConfigVariable registers duration config variable
 // Deprecated: use RegisterDurationVar or RegisterAtomicDurationVar instead
-func RegisterDurationConfigVariable(defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string) {
+func RegisterDurationConfigVariable(
+	defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string,
+) {
 	Default.RegisterDurationConfigVariable(defaultValueInTimescaleUnits, ptr, isHotReloadable, timeScale, keys...)
 }
 
 // RegisterDurationVar registers a not hot-reloadable duration config variable
-func RegisterDurationVar(defaultValueInTimescaleUnits int64, ptr *time.Duration, timeScale time.Duration, keys ...string) {
+func RegisterDurationVar(
+	defaultValueInTimescaleUnits int64, ptr *time.Duration, timeScale time.Duration, keys ...string,
+) {
 	Default.RegisterDurationVar(defaultValueInTimescaleUnits, ptr, timeScale, keys...)
 }
 
 // RegisterAtomicDurationVar registers a not hot-reloadable duration config variable
-func RegisterAtomicDurationVar(defaultValueInTimescaleUnits int64, ptr *Atomic[time.Duration], timeScale time.Duration, keys ...string) {
+func RegisterAtomicDurationVar(
+	defaultValueInTimescaleUnits int64, ptr *Atomic[time.Duration], timeScale time.Duration, keys ...string,
+) {
 	Default.RegisterAtomicDurationVar(defaultValueInTimescaleUnits, ptr, timeScale, keys...)
 }
 

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -41,7 +41,7 @@ func (c *Config) RegisterIntVar(defaultValue int, ptr *int, valueScale int, keys
 // RegisterAtomicIntVar registers a hot-reloadable int config variable
 // Copy of RegisterIntConfigVariable, but with a way to avoid data races for hot reloadable config variables
 func (c *Config) RegisterAtomicIntVar(defaultValue, valueScale int, keys ...string) *Atomic[int] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerIntVar(defaultValue, ptr, true, valueScale, func(v int) {
 		ptr.store(v)
 	}, keys...)
@@ -108,7 +108,7 @@ func (c *Config) RegisterBoolVar(defaultValue bool, ptr *bool, keys ...string) {
 
 // RegisterAtomicBoolVar registers a hot-reloadable bool config variable
 func (c *Config) RegisterAtomicBoolVar(defaultValue bool, keys ...string) *Atomic[bool] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerBoolVar(defaultValue, ptr, true, func(v bool) {
 		ptr.store(v)
 	}, keys...)
@@ -173,7 +173,7 @@ func (c *Config) RegisterFloat64Var(defaultValue float64, ptr *float64, keys ...
 
 // RegisterAtomicFloat64Var registers a hot-reloadable float64 config variable
 func (c *Config) RegisterAtomicFloat64Var(defaultValue float64, keys ...string) *Atomic[float64] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerFloat64Var(defaultValue, ptr, true, func(v float64) {
 		ptr.store(v)
 	}, keys...)
@@ -243,7 +243,7 @@ func (c *Config) RegisterInt64Var(defaultValue int64, ptr *int64, valueScale int
 
 // RegisterAtomicInt64Var registers a not hot-reloadable int64 config variable
 func (c *Config) RegisterAtomicInt64Var(defaultValue, valueScale int64, keys ...string) *Atomic[int64] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerInt64Var(defaultValue, ptr, true, valueScale, func(v int64) {
 		ptr.store(v)
 	}, keys...)
@@ -322,7 +322,7 @@ func (c *Config) RegisterAtomicDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, keys ...string,
 ) *Atomic[time.Duration] {
 	ptr := getOrCreatePointer(
-		c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, time.Duration(defaultValueInTimescaleUnits), keys...,
+		&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, time.Duration(defaultValueInTimescaleUnits), keys...,
 	)
 	c.registerDurationVar(defaultValueInTimescaleUnits, ptr, true, timeScale, func(v time.Duration) {
 		ptr.store(v)
@@ -391,7 +391,7 @@ func (c *Config) RegisterStringVar(defaultValue string, ptr *string, keys ...str
 
 // RegisterAtomicStringVar registers a hot-reloadable string config variable
 func (c *Config) RegisterAtomicStringVar(defaultValue string, keys ...string) *Atomic[string] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerStringVar(defaultValue, ptr, true, func(v string) {
 		ptr.store(v)
 	}, keys...)
@@ -457,7 +457,7 @@ func (c *Config) RegisterStringSliceVar(defaultValue []string, ptr *[]string, ke
 
 // RegisterAtomicStringSliceVar registers a hot-reloadable string slice config variable
 func (c *Config) RegisterAtomicStringSliceVar(defaultValue []string, keys ...string) *Atomic[[]string] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerStringSliceVar(defaultValue, ptr, true, func(v []string) {
 		ptr.store(v)
 	}, keys...)
@@ -535,7 +535,7 @@ func (c *Config) RegisterStringMapVar(
 func (c *Config) RegisterAtomicStringMapVar(
 	defaultValue map[string]interface{}, keys ...string,
 ) *Atomic[map[string]interface{}] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+	ptr := getOrCreatePointer(&c.atomicVars, &c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerStringMapVar(defaultValue, ptr, true, func(v map[string]interface{}) {
 		ptr.store(v)
 	}, keys...)

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -434,8 +434,8 @@ func RegisterStringSliceVar(defaultValue []string, ptr *[]string, keys ...string
 }
 
 // RegisterAtomicStringSliceVar registers a hot-reloadable string slice config variable
-func RegisterAtomicStringSliceVar(defaultValue []string, ptr *Atomic[[]string], keys ...string) {
-	Default.RegisterAtomicStringSliceVar(defaultValue, ptr, keys...)
+func RegisterAtomicStringSliceVar(defaultValue []string, keys ...string) *Atomic[[]string] {
+	return Default.RegisterAtomicStringSliceVar(defaultValue, keys...)
 }
 
 // RegisterStringSliceConfigVariable registers string slice config variable
@@ -456,10 +456,12 @@ func (c *Config) RegisterStringSliceVar(defaultValue []string, ptr *[]string, ke
 }
 
 // RegisterAtomicStringSliceVar registers a hot-reloadable string slice config variable
-func (c *Config) RegisterAtomicStringSliceVar(defaultValue []string, ptr *Atomic[[]string], keys ...string) {
+func (c *Config) RegisterAtomicStringSliceVar(defaultValue []string, keys ...string) *Atomic[[]string] {
+	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerStringSliceVar(defaultValue, ptr, true, func(v []string) {
 		ptr.store(v)
 	}, keys...)
+	return ptr
 }
 
 func (c *Config) registerStringSliceVar(
@@ -505,9 +507,9 @@ func RegisterStringMapVar(
 
 // RegisterAtomicStringMapVar registers a hot-reloadable string map config variable
 func RegisterAtomicStringMapVar(
-	defaultValue map[string]interface{}, ptr *Atomic[map[string]interface{}], keys ...string,
-) {
-	Default.RegisterAtomicStringMapVar(defaultValue, ptr, keys...)
+	defaultValue map[string]interface{}, keys ...string,
+) *Atomic[map[string]interface{}] {
+	return Default.RegisterAtomicStringMapVar(defaultValue, keys...)
 }
 
 // RegisterStringMapConfigVariable registers string map config variable
@@ -531,11 +533,13 @@ func (c *Config) RegisterStringMapVar(
 
 // RegisterAtomicStringMapVar registers a hot-reloadable string map config variable
 func (c *Config) RegisterAtomicStringMapVar(
-	defaultValue map[string]interface{}, ptr *Atomic[map[string]interface{}], keys ...string,
-) {
+	defaultValue map[string]interface{}, keys ...string,
+) *Atomic[map[string]interface{}] {
+	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerStringMapVar(defaultValue, ptr, true, func(v map[string]interface{}) {
 		ptr.store(v)
 	}, keys...)
+	return ptr
 }
 
 func (c *Config) registerStringMapVar(

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -748,6 +748,7 @@ func (a *Reloadable[T]) store(v T) {
 }
 
 // swapIfNotEqual is used internally to swap the value of a hot-reloadable config variable
+// if the new value is not equal to the old value
 func (a *Reloadable[T]) swapIfNotEqual(new T, compare func(old, new T) bool) (old T, swapped bool) {
 	a.lock.Lock()
 	defer a.lock.Unlock()

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -6,8 +6,21 @@ import (
 )
 
 // RegisterIntConfigVariable registers int config variable
+// Deprecated: use RegisterIntVar or RegisterAtomicIntVar instead
 func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
-	Default.RegisterIntConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
+	Default.registerIntVar(defaultValue, ptr, isHotReloadable, valueScale, func(v int) {
+		*ptr = v
+	}, keys...)
+}
+
+// RegisterIntVar registers a not hot-reloadable int config variable
+func RegisterIntVar(defaultValue int, ptr *int, valueScale int, keys ...string) {
+	Default.RegisterIntVar(defaultValue, ptr, valueScale, keys...)
+}
+
+// RegisterAtomicIntVar registers a hot-reloadable int config variable
+func RegisterAtomicIntVar(defaultValue int, ptr *Atomic[int], valueScale int, keys ...string) {
+	Default.RegisterAtomicIntVar(defaultValue, ptr, valueScale, keys...)
 }
 
 // RegisterIntConfigVariable registers int config variable
@@ -154,8 +167,21 @@ func (c *Config) RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isH
 }
 
 // RegisterDurationConfigVariable registers duration config variable
+// Deprecated: use RegisterDurationVar or RegisterAtomicDurationVar instead
 func RegisterDurationConfigVariable(defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string) {
-	Default.RegisterDurationConfigVariable(defaultValueInTimescaleUnits, ptr, isHotReloadable, timeScale, keys...)
+	Default.registerDurationVar(defaultValueInTimescaleUnits, ptr, isHotReloadable, timeScale, func(v time.Duration) {
+		*ptr = v
+	}, keys...)
+}
+
+// RegisterDurationVar registers a not hot-reloadable duration config variable
+func RegisterDurationVar(defaultValueInTimescaleUnits int64, ptr *time.Duration, timeScale time.Duration, keys ...string) {
+	Default.RegisterDurationVar(defaultValueInTimescaleUnits, ptr, timeScale, keys...)
+}
+
+// RegisterAtomicDurationVar registers a not hot-reloadable duration config variable
+func RegisterAtomicDurationVar(defaultValueInTimescaleUnits int64, ptr *Atomic[time.Duration], timeScale time.Duration, keys ...string) {
+	Default.RegisterAtomicDurationVar(defaultValueInTimescaleUnits, ptr, timeScale, keys...)
 }
 
 // RegisterDurationConfigVariable registers duration config variable

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -8,9 +8,7 @@ import (
 // RegisterIntConfigVariable registers int config variable
 // Deprecated: use RegisterIntVar or RegisterAtomicIntVar instead
 func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
-	Default.registerIntVar(defaultValue, ptr, isHotReloadable, valueScale, func(v int) {
-		*ptr = v
-	}, keys...)
+	Default.RegisterIntConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
 }
 
 // RegisterIntVar registers a not hot-reloadable int config variable
@@ -72,12 +70,44 @@ func (c *Config) registerIntVar(defaultValue int, ptr any, isHotReloadable bool,
 }
 
 // RegisterBoolConfigVariable registers bool config variable
+// Deprecated: use RegisterBoolVar or RegisterAtomicBoolVar instead
 func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, keys ...string) {
 	Default.RegisterBoolConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
 
+// RegisterBoolVar registers a not hot-reloadable bool config variable
+func RegisterBoolVar(defaultValue bool, ptr *bool, keys ...string) {
+	Default.RegisterBoolVar(defaultValue, ptr, keys...)
+}
+
+// RegisterAtomicBoolVar registers a hot-reloadable bool config variable
+func RegisterAtomicBoolVar(defaultValue bool, ptr *Atomic[bool], keys ...string) {
+	Default.RegisterAtomicBoolVar(defaultValue, ptr, keys...)
+}
+
 // RegisterBoolConfigVariable registers bool config variable
+// Deprecated: use RegisterBoolVar or RegisterAtomicBoolVar instead
 func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, keys ...string) {
+	c.registerBoolVar(defaultValue, ptr, isHotReloadable, func(v bool) {
+		*ptr = v
+	}, keys...)
+}
+
+// RegisterBoolVar registers a not hot-reloadable bool config variable
+func (c *Config) RegisterBoolVar(defaultValue bool, ptr *bool, keys ...string) {
+	c.registerBoolVar(defaultValue, ptr, false, func(v bool) {
+		*ptr = v
+	}, keys...)
+}
+
+// RegisterAtomicBoolVar registers a hot-reloadable bool config variable
+func (c *Config) RegisterAtomicBoolVar(defaultValue bool, ptr *Atomic[bool], keys ...string) {
+	c.registerBoolVar(defaultValue, ptr, true, func(v bool) {
+		ptr.Store(v)
+	}, keys...)
+}
+
+func (c *Config) registerBoolVar(defaultValue bool, ptr any, isHotReloadable bool, store func(bool), keys ...string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
 	c.hotReloadableConfigLock.Lock()
@@ -95,11 +125,11 @@ func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotR
 	for _, key := range keys {
 		c.bindEnv(key)
 		if c.IsSet(key) {
-			*ptr = c.GetBool(key, defaultValue)
+			store(c.GetBool(key, defaultValue))
 			return
 		}
 	}
-	*ptr = defaultValue
+	store(defaultValue)
 }
 
 // RegisterFloat64ConfigVariable registers float64 config variable
@@ -169,9 +199,7 @@ func (c *Config) RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isH
 // RegisterDurationConfigVariable registers duration config variable
 // Deprecated: use RegisterDurationVar or RegisterAtomicDurationVar instead
 func RegisterDurationConfigVariable(defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string) {
-	Default.registerDurationVar(defaultValueInTimescaleUnits, ptr, isHotReloadable, timeScale, func(v time.Duration) {
-		*ptr = v
-	}, keys...)
+	Default.RegisterDurationConfigVariable(defaultValueInTimescaleUnits, ptr, isHotReloadable, timeScale, keys...)
 }
 
 // RegisterDurationVar registers a not hot-reloadable duration config variable

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -6,7 +6,7 @@ import (
 )
 
 // RegisterIntConfigVariable registers int config variable
-// Deprecated: use RegisterIntVar or RegisterAtomicIntVar instead
+// Deprecated: use RegisterIntVar or RegisterReloadableIntVar instead
 func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
 	Default.RegisterIntConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
 }
@@ -16,13 +16,13 @@ func RegisterIntVar(defaultValue int, ptr *int, valueScale int, keys ...string) 
 	Default.RegisterIntVar(defaultValue, ptr, valueScale, keys...)
 }
 
-// RegisterAtomicIntVar registers a hot-reloadable int config variable
-func RegisterAtomicIntVar(defaultValue, valueScale int, keys ...string) *Atomic[int] {
-	return Default.RegisterAtomicIntVar(defaultValue, valueScale, keys...)
+// RegisterReloadableIntVar registers a hot-reloadable int config variable
+func RegisterReloadableIntVar(defaultValue, valueScale int, keys ...string) *Reloadable[int] {
+	return Default.RegisterReloadableIntVar(defaultValue, valueScale, keys...)
 }
 
 // RegisterIntConfigVariable registers int config variable
-// Deprecated: use RegisterIntVar or RegisterAtomicIntVar instead
+// Deprecated: use RegisterIntVar or RegisterReloadableIntVar instead
 func (c *Config) RegisterIntConfigVariable(
 	defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string,
 ) {
@@ -38,10 +38,10 @@ func (c *Config) RegisterIntVar(defaultValue int, ptr *int, valueScale int, keys
 	}, keys...)
 }
 
-// RegisterAtomicIntVar registers a hot-reloadable int config variable
+// RegisterReloadableIntVar registers a hot-reloadable int config variable
 // Copy of RegisterIntConfigVariable, but with a way to avoid data races for hot reloadable config variables
-func (c *Config) RegisterAtomicIntVar(defaultValue, valueScale int, keys ...string) *Atomic[int] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+func (c *Config) RegisterReloadableIntVar(defaultValue, valueScale int, keys ...string) *Reloadable[int] {
+	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, keys...)
 	c.registerIntVar(defaultValue, ptr, true, valueScale, func(v int) {
 		ptr.store(v)
 	}, keys...)
@@ -76,7 +76,7 @@ func (c *Config) registerIntVar(
 }
 
 // RegisterBoolConfigVariable registers bool config variable
-// Deprecated: use RegisterBoolVar or RegisterAtomicBoolVar instead
+// Deprecated: use RegisterBoolVar or RegisterReloadableBoolVar instead
 func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, keys ...string) {
 	Default.RegisterBoolConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
@@ -86,13 +86,13 @@ func RegisterBoolVar(defaultValue bool, ptr *bool, keys ...string) {
 	Default.RegisterBoolVar(defaultValue, ptr, keys...)
 }
 
-// RegisterAtomicBoolVar registers a hot-reloadable bool config variable
-func RegisterAtomicBoolVar(defaultValue bool, keys ...string) *Atomic[bool] {
-	return Default.RegisterAtomicBoolVar(defaultValue, keys...)
+// RegisterReloadableBoolVar registers a hot-reloadable bool config variable
+func RegisterReloadableBoolVar(defaultValue bool, keys ...string) *Reloadable[bool] {
+	return Default.RegisterReloadableBoolVar(defaultValue, keys...)
 }
 
 // RegisterBoolConfigVariable registers bool config variable
-// Deprecated: use RegisterBoolVar or RegisterAtomicBoolVar instead
+// Deprecated: use RegisterBoolVar or RegisterReloadableBoolVar instead
 func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, keys ...string) {
 	c.registerBoolVar(defaultValue, ptr, isHotReloadable, func(v bool) {
 		*ptr = v
@@ -106,9 +106,9 @@ func (c *Config) RegisterBoolVar(defaultValue bool, ptr *bool, keys ...string) {
 	}, keys...)
 }
 
-// RegisterAtomicBoolVar registers a hot-reloadable bool config variable
-func (c *Config) RegisterAtomicBoolVar(defaultValue bool, keys ...string) *Atomic[bool] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+// RegisterReloadableBoolVar registers a hot-reloadable bool config variable
+func (c *Config) RegisterReloadableBoolVar(defaultValue bool, keys ...string) *Reloadable[bool] {
+	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, keys...)
 	c.registerBoolVar(defaultValue, ptr, true, func(v bool) {
 		ptr.store(v)
 	}, keys...)
@@ -141,7 +141,7 @@ func (c *Config) registerBoolVar(defaultValue bool, ptr any, isHotReloadable boo
 }
 
 // RegisterFloat64ConfigVariable registers float64 config variable
-// Deprecated: use RegisterFloat64Var or RegisterAtomicFloat64Var instead
+// Deprecated: use RegisterFloat64Var or RegisterReloadableFloat64Var instead
 func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, keys ...string) {
 	Default.RegisterFloat64ConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
@@ -151,13 +151,13 @@ func RegisterFloat64Var(defaultValue float64, ptr *float64, keys ...string) {
 	Default.RegisterFloat64Var(defaultValue, ptr, keys...)
 }
 
-// RegisterAtomicFloat64Var registers a hot-reloadable float64 config variable
-func RegisterAtomicFloat64Var(defaultValue float64, keys ...string) *Atomic[float64] {
-	return Default.RegisterAtomicFloat64Var(defaultValue, keys...)
+// RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
+func RegisterReloadableFloat64Var(defaultValue float64, keys ...string) *Reloadable[float64] {
+	return Default.RegisterReloadableFloat64Var(defaultValue, keys...)
 }
 
 // RegisterFloat64ConfigVariable registers float64 config variable
-// Deprecated: use RegisterFloat64Var or RegisterAtomicFloat64Var instead
+// Deprecated: use RegisterFloat64Var or RegisterReloadableFloat64Var instead
 func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, keys ...string) {
 	c.registerFloat64Var(defaultValue, ptr, isHotReloadable, func(v float64) {
 		*ptr = v
@@ -171,9 +171,9 @@ func (c *Config) RegisterFloat64Var(defaultValue float64, ptr *float64, keys ...
 	}, keys...)
 }
 
-// RegisterAtomicFloat64Var registers a hot-reloadable float64 config variable
-func (c *Config) RegisterAtomicFloat64Var(defaultValue float64, keys ...string) *Atomic[float64] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+// RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
+func (c *Config) RegisterReloadableFloat64Var(defaultValue float64, keys ...string) *Reloadable[float64] {
+	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, keys...)
 	c.registerFloat64Var(defaultValue, ptr, true, func(v float64) {
 		ptr.store(v)
 	}, keys...)
@@ -209,7 +209,7 @@ func (c *Config) registerFloat64Var(
 }
 
 // RegisterInt64ConfigVariable registers int64 config variable
-// Deprecated: use RegisterInt64Var or RegisterAtomicInt64Var instead
+// Deprecated: use RegisterInt64Var or RegisterReloadableInt64Var instead
 func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string) {
 	Default.RegisterInt64ConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, keys...)
 }
@@ -219,13 +219,13 @@ func RegisterInt64Var(defaultValue int64, ptr *int64, valueScale int64, keys ...
 	Default.RegisterInt64Var(defaultValue, ptr, valueScale, keys...)
 }
 
-// RegisterAtomicInt64Var registers a hot-reloadable int64 config variable
-func RegisterAtomicInt64Var(defaultValue, valueScale int64, keys ...string) *Atomic[int64] {
-	return Default.RegisterAtomicInt64Var(defaultValue, valueScale, keys...)
+// RegisterReloadableInt64Var registers a hot-reloadable int64 config variable
+func RegisterReloadableInt64Var(defaultValue, valueScale int64, keys ...string) *Reloadable[int64] {
+	return Default.RegisterReloadableInt64Var(defaultValue, valueScale, keys...)
 }
 
 // RegisterInt64ConfigVariable registers int64 config variable
-// Deprecated: use RegisterInt64Var or RegisterAtomicInt64Var instead
+// Deprecated: use RegisterInt64Var or RegisterReloadableInt64Var instead
 func (c *Config) RegisterInt64ConfigVariable(
 	defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, keys ...string,
 ) {
@@ -241,9 +241,9 @@ func (c *Config) RegisterInt64Var(defaultValue int64, ptr *int64, valueScale int
 	}, keys...)
 }
 
-// RegisterAtomicInt64Var registers a not hot-reloadable int64 config variable
-func (c *Config) RegisterAtomicInt64Var(defaultValue, valueScale int64, keys ...string) *Atomic[int64] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+// RegisterReloadableInt64Var registers a not hot-reloadable int64 config variable
+func (c *Config) RegisterReloadableInt64Var(defaultValue, valueScale int64, keys ...string) *Reloadable[int64] {
+	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, keys...)
 	c.registerInt64Var(defaultValue, ptr, true, valueScale, func(v int64) {
 		ptr.store(v)
 	}, keys...)
@@ -279,7 +279,7 @@ func (c *Config) registerInt64Var(
 }
 
 // RegisterDurationConfigVariable registers duration config variable
-// Deprecated: use RegisterDurationVar or RegisterAtomicDurationVar instead
+// Deprecated: use RegisterDurationVar or RegisterReloadableDurationVar instead
 func RegisterDurationConfigVariable(
 	defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string,
 ) {
@@ -293,13 +293,13 @@ func RegisterDurationVar(
 	Default.RegisterDurationVar(defaultValueInTimescaleUnits, ptr, timeScale, keys...)
 }
 
-// RegisterAtomicDurationVar registers a not hot-reloadable duration config variable
-func RegisterAtomicDurationVar(defaultValueInTimescaleUnits int64, timeScale time.Duration, keys ...string) *Atomic[time.Duration] {
-	return Default.RegisterAtomicDurationVar(defaultValueInTimescaleUnits, timeScale, keys...)
+// RegisterReloadableDurationVar registers a not hot-reloadable duration config variable
+func RegisterReloadableDurationVar(defaultValueInTimescaleUnits int64, timeScale time.Duration, keys ...string) *Reloadable[time.Duration] {
+	return Default.RegisterReloadableDurationVar(defaultValueInTimescaleUnits, timeScale, keys...)
 }
 
 // RegisterDurationConfigVariable registers duration config variable
-// Deprecated: use RegisterDurationVar or RegisterAtomicDurationVar instead
+// Deprecated: use RegisterDurationVar or RegisterReloadableDurationVar instead
 func (c *Config) RegisterDurationConfigVariable(
 	defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, keys ...string,
 ) {
@@ -317,12 +317,12 @@ func (c *Config) RegisterDurationVar(
 	}, keys...)
 }
 
-// RegisterAtomicDurationVar registers a hot-reloadable duration config variable
-func (c *Config) RegisterAtomicDurationVar(
+// RegisterReloadableDurationVar registers a hot-reloadable duration config variable
+func (c *Config) RegisterReloadableDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, keys ...string,
-) *Atomic[time.Duration] {
+) *Reloadable[time.Duration] {
 	ptr := getOrCreatePointer(
-		c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, time.Duration(defaultValueInTimescaleUnits), keys...,
+		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, time.Duration(defaultValueInTimescaleUnits), keys...,
 	)
 	c.registerDurationVar(defaultValueInTimescaleUnits, ptr, true, timeScale, func(v time.Duration) {
 		ptr.store(v)
@@ -359,7 +359,7 @@ func (c *Config) registerDurationVar(
 }
 
 // RegisterStringConfigVariable registers string config variable
-// Deprecated: use RegisterStringVar or RegisterAtomicStringVar instead
+// Deprecated: use RegisterStringVar or RegisterReloadableStringVar instead
 func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, keys ...string) {
 	Default.RegisterStringConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
@@ -369,13 +369,13 @@ func RegisterStringVar(defaultValue string, ptr *string, keys ...string) {
 	Default.RegisterStringVar(defaultValue, ptr, keys...)
 }
 
-// RegisterAtomicStringVar registers a hot-reloadable string config variable
-func RegisterAtomicStringVar(defaultValue string, keys ...string) *Atomic[string] {
-	return Default.RegisterAtomicStringVar(defaultValue, keys...)
+// RegisterReloadableStringVar registers a hot-reloadable string config variable
+func RegisterReloadableStringVar(defaultValue string, keys ...string) *Reloadable[string] {
+	return Default.RegisterReloadableStringVar(defaultValue, keys...)
 }
 
 // RegisterStringConfigVariable registers string config variable
-// Deprecated: use RegisterStringVar or RegisterAtomicStringVar instead
+// Deprecated: use RegisterStringVar or RegisterReloadableStringVar instead
 func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, keys ...string) {
 	c.registerStringVar(defaultValue, ptr, isHotReloadable, func(v string) {
 		*ptr = v
@@ -389,9 +389,9 @@ func (c *Config) RegisterStringVar(defaultValue string, ptr *string, keys ...str
 	}, keys...)
 }
 
-// RegisterAtomicStringVar registers a hot-reloadable string config variable
-func (c *Config) RegisterAtomicStringVar(defaultValue string, keys ...string) *Atomic[string] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+// RegisterReloadableStringVar registers a hot-reloadable string config variable
+func (c *Config) RegisterReloadableStringVar(defaultValue string, keys ...string) *Reloadable[string] {
+	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, keys...)
 	c.registerStringVar(defaultValue, ptr, true, func(v string) {
 		ptr.store(v)
 	}, keys...)
@@ -423,7 +423,7 @@ func (c *Config) registerStringVar(defaultValue string, ptr any, isHotReloadable
 }
 
 // RegisterStringSliceConfigVariable registers string slice config variable
-// Deprecated: use RegisterStringSliceVar or RegisterAtomicStringSliceVar instead
+// Deprecated: use RegisterStringSliceVar or RegisterReloadableStringSliceVar instead
 func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isHotReloadable bool, keys ...string) {
 	Default.RegisterStringSliceConfigVariable(defaultValue, ptr, isHotReloadable, keys...)
 }
@@ -433,13 +433,13 @@ func RegisterStringSliceVar(defaultValue []string, ptr *[]string, keys ...string
 	Default.RegisterStringSliceVar(defaultValue, ptr, keys...)
 }
 
-// RegisterAtomicStringSliceVar registers a hot-reloadable string slice config variable
-func RegisterAtomicStringSliceVar(defaultValue []string, keys ...string) *Atomic[[]string] {
-	return Default.RegisterAtomicStringSliceVar(defaultValue, keys...)
+// RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
+func RegisterReloadableStringSliceVar(defaultValue []string, keys ...string) *Reloadable[[]string] {
+	return Default.RegisterReloadableStringSliceVar(defaultValue, keys...)
 }
 
 // RegisterStringSliceConfigVariable registers string slice config variable
-// Deprecated: use RegisterStringSliceVar or RegisterAtomicStringSliceVar instead
+// Deprecated: use RegisterStringSliceVar or RegisterReloadableStringSliceVar instead
 func (c *Config) RegisterStringSliceConfigVariable(
 	defaultValue []string, ptr *[]string, isHotReloadable bool, keys ...string,
 ) {
@@ -455,9 +455,9 @@ func (c *Config) RegisterStringSliceVar(defaultValue []string, ptr *[]string, ke
 	}, keys...)
 }
 
-// RegisterAtomicStringSliceVar registers a hot-reloadable string slice config variable
-func (c *Config) RegisterAtomicStringSliceVar(defaultValue []string, keys ...string) *Atomic[[]string] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+// RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
+func (c *Config) RegisterReloadableStringSliceVar(defaultValue []string, keys ...string) *Reloadable[[]string] {
+	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, keys...)
 	c.registerStringSliceVar(defaultValue, ptr, true, func(v []string) {
 		ptr.store(v)
 	}, keys...)
@@ -491,7 +491,7 @@ func (c *Config) registerStringSliceVar(
 }
 
 // RegisterStringMapConfigVariable registers string map config variable
-// Deprecated: use RegisterStringMapVar or RegisterAtomicStringMapVar instead
+// Deprecated: use RegisterStringMapVar or RegisterReloadableStringMapVar instead
 func RegisterStringMapConfigVariable(
 	defaultValue map[string]interface{}, ptr *map[string]interface{}, isHotReloadable bool, keys ...string,
 ) {
@@ -505,15 +505,15 @@ func RegisterStringMapVar(
 	Default.RegisterStringMapVar(defaultValue, ptr, keys...)
 }
 
-// RegisterAtomicStringMapVar registers a hot-reloadable string map config variable
-func RegisterAtomicStringMapVar(
+// RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
+func RegisterReloadableStringMapVar(
 	defaultValue map[string]interface{}, keys ...string,
-) *Atomic[map[string]interface{}] {
-	return Default.RegisterAtomicStringMapVar(defaultValue, keys...)
+) *Reloadable[map[string]interface{}] {
+	return Default.RegisterReloadableStringMapVar(defaultValue, keys...)
 }
 
 // RegisterStringMapConfigVariable registers string map config variable
-// Deprecated: use RegisterStringMapVar or RegisterAtomicStringMapVar instead
+// Deprecated: use RegisterStringMapVar or RegisterReloadableStringMapVar instead
 func (c *Config) RegisterStringMapConfigVariable(
 	defaultValue map[string]interface{}, ptr *map[string]interface{}, isHotReloadable bool, keys ...string,
 ) {
@@ -531,11 +531,11 @@ func (c *Config) RegisterStringMapVar(
 	}, keys...)
 }
 
-// RegisterAtomicStringMapVar registers a hot-reloadable string map config variable
-func (c *Config) RegisterAtomicStringMapVar(
+// RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
+func (c *Config) RegisterReloadableStringMapVar(
 	defaultValue map[string]interface{}, keys ...string,
-) *Atomic[map[string]interface{}] {
-	ptr := getOrCreatePointer(c.atomicVars, c.atomicVarsMisuses, &c.atomicVarsLock, defaultValue, keys...)
+) *Reloadable[map[string]interface{}] {
+	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, keys...)
 	c.registerStringMapVar(defaultValue, ptr, true, func(v map[string]interface{}) {
 		ptr.store(v)
 	}, keys...)
@@ -579,28 +579,28 @@ type configTypes interface {
 	int | int64 | string | time.Duration | bool | float64 | []string | map[string]interface{}
 }
 
-// Atomic is used as a wrapper for hot-reloadable config variables
-type Atomic[T configTypes] struct {
+// Reloadable is used as a wrapper for hot-reloadable config variables
+type Reloadable[T configTypes] struct {
 	value T
 	lock  sync.RWMutex
 }
 
 // Load should be used to read the underlying value without worrying about data races
-func (a *Atomic[T]) Load() T {
+func (a *Reloadable[T]) Load() T {
 	a.lock.RLock()
 	v := a.value
 	a.lock.RUnlock()
 	return v
 }
 
-func (a *Atomic[T]) store(v T) {
+func (a *Reloadable[T]) store(v T) {
 	a.lock.Lock()
 	a.value = v
 	a.lock.Unlock()
 }
 
 // swapIfNotEqual is used internally to swap the value of a hot-reloadable config variable
-func (a *Atomic[T]) swapIfNotEqual(new T, compare func(old, new T) bool) (old T, swapped bool) {
+func (a *Reloadable[T]) swapIfNotEqual(new T, compare func(old, new T) bool) (old T, swapped bool) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	if !compare(a.value, new) {

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -1,6 +1,9 @@
 package config
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
 
 // RegisterIntConfigVariable registers int config variable
 func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
@@ -8,7 +11,29 @@ func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool,
 }
 
 // RegisterIntConfigVariable registers int config variable
+// Deprecated: use RegisterIntVar or RegisterAtomicIntVar instead
 func (c *Config) RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, keys ...string) {
+	c.registerIntConfigVar(defaultValue, ptr, isHotReloadable, valueScale, func(v int) {
+		*ptr = v
+	}, keys...)
+}
+
+// RegisterIntVar registers a not hot-reloadable int config variable
+func (c *Config) RegisterIntVar(defaultValue int, ptr *int, valueScale int, keys ...string) {
+	c.registerIntConfigVar(defaultValue, ptr, false, valueScale, func(v int) {
+		*ptr = v
+	}, keys...)
+}
+
+// RegisterAtomicIntVar registers a hot-reloadable int config variable
+// Copy of RegisterIntConfigVariable, but with a way to avoid data races for hot reloadable config variables
+func (c *Config) RegisterAtomicIntVar(defaultValue int, ptr *Atomic[int], valueScale int, keys ...string) {
+	c.registerIntConfigVar(defaultValue, ptr, true, valueScale, func(v int) {
+		ptr.Store(v)
+	}, keys...)
+}
+
+func (c *Config) registerIntConfigVar(defaultValue int, ptr any, isHotReloadable bool, valueScale int, store func(int), keys ...string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
 	c.hotReloadableConfigLock.Lock()
@@ -26,11 +51,11 @@ func (c *Config) RegisterIntConfigVariable(defaultValue int, ptr *int, isHotRelo
 
 	for _, key := range keys {
 		if c.IsSet(key) {
-			*ptr = c.GetInt(key, defaultValue) * valueScale
+			store(c.GetInt(key, defaultValue) * valueScale)
 			return
 		}
 	}
-	*ptr = defaultValue * valueScale
+	store(defaultValue * valueScale)
 }
 
 // RegisterBoolConfigVariable registers bool config variable
@@ -254,4 +279,16 @@ func (c *Config) appendVarToConfigMaps(key string, configVar *configValue) {
 		c.hotReloadableConfig[key] = make([]*configValue, 0)
 	}
 	c.hotReloadableConfig[key] = append(c.hotReloadableConfig[key], configVar)
+}
+
+type Atomic[T any] struct {
+	atomic.Value
+}
+
+func (a *Atomic[T]) Load() T {
+	return a.Value.Load().(T)
+}
+
+func (a *Atomic[T]) Store(v T) {
+	a.Value.Store(v)
 }

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -8,6 +8,7 @@ import (
 
 // RegisterIntConfigVariable registers int config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterIntVar or RegisterReloadableIntVar instead
 func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, orderedKeys ...string) {
 	Default.RegisterIntConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, orderedKeys...)
@@ -27,6 +28,7 @@ func RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...strin
 
 // RegisterIntConfigVariable registers int config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterIntVar or RegisterReloadableIntVar instead
 func (c *Config) RegisterIntConfigVariable(
 	defaultValue int, ptr *int, isHotReloadable bool, valueScale int, orderedKeys ...string,
@@ -85,6 +87,7 @@ func (c *Config) registerIntVar(
 
 // RegisterBoolConfigVariable registers bool config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterBoolVar or RegisterReloadableBoolVar instead
 func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, orderedKeys ...string) {
 	Default.RegisterBoolConfigVariable(defaultValue, ptr, isHotReloadable, orderedKeys...)
@@ -104,6 +107,7 @@ func RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reload
 
 // RegisterBoolConfigVariable registers bool config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterBoolVar or RegisterReloadableBoolVar instead
 func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, orderedKeys ...string) {
 	c.registerBoolVar(defaultValue, ptr, isHotReloadable, func(v bool) {
@@ -158,6 +162,7 @@ func (c *Config) registerBoolVar(defaultValue bool, ptr any, isHotReloadable boo
 
 // RegisterFloat64ConfigVariable registers float64 config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterFloat64Var or RegisterReloadableFloat64Var instead
 func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, orderedKeys ...string) {
 	Default.RegisterFloat64ConfigVariable(defaultValue, ptr, isHotReloadable, orderedKeys...)
@@ -177,6 +182,7 @@ func RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *
 
 // RegisterFloat64ConfigVariable registers float64 config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterFloat64Var or RegisterReloadableFloat64Var instead
 func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, orderedKeys ...string) {
 	c.registerFloat64Var(defaultValue, ptr, isHotReloadable, func(v float64) {
@@ -234,6 +240,7 @@ func (c *Config) registerFloat64Var(
 
 // RegisterInt64ConfigVariable registers int64 config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterInt64Var or RegisterReloadableInt64Var instead
 func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, orderedKeys ...string) {
 	Default.RegisterInt64ConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, orderedKeys...)
@@ -253,6 +260,7 @@ func RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...s
 
 // RegisterInt64ConfigVariable registers int64 config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterInt64Var or RegisterReloadableInt64Var instead
 func (c *Config) RegisterInt64ConfigVariable(
 	defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, orderedKeys ...string,
@@ -312,6 +320,7 @@ func (c *Config) registerInt64Var(
 
 // RegisterDurationConfigVariable registers duration config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterDurationVar or RegisterReloadableDurationVar instead
 func RegisterDurationConfigVariable(
 	defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, orderedKeys ...string,
@@ -335,6 +344,7 @@ func RegisterReloadableDurationVar(defaultValueInTimescaleUnits int64, timeScale
 
 // RegisterDurationConfigVariable registers duration config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterDurationVar or RegisterReloadableDurationVar instead
 func (c *Config) RegisterDurationConfigVariable(
 	defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, orderedKeys ...string,
@@ -402,6 +412,7 @@ func (c *Config) registerDurationVar(
 
 // RegisterStringConfigVariable registers string config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterStringVar or RegisterReloadableStringVar instead
 func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, orderedKeys ...string) {
 	Default.RegisterStringConfigVariable(defaultValue, ptr, isHotReloadable, orderedKeys...)
@@ -421,6 +432,7 @@ func RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Re
 
 // RegisterStringConfigVariable registers string config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterStringVar or RegisterReloadableStringVar instead
 func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, orderedKeys ...string) {
 	c.registerStringVar(defaultValue, ptr, isHotReloadable, func(v string) {
@@ -474,6 +486,7 @@ func (c *Config) registerStringVar(defaultValue string, ptr any, isHotReloadable
 
 // RegisterStringSliceConfigVariable registers string slice config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterStringSliceVar or RegisterReloadableStringSliceVar instead
 func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isHotReloadable bool, orderedKeys ...string) {
 	Default.RegisterStringSliceConfigVariable(defaultValue, ptr, isHotReloadable, orderedKeys...)
@@ -493,6 +506,7 @@ func RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...stri
 
 // RegisterStringSliceConfigVariable registers string slice config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterStringSliceVar or RegisterReloadableStringSliceVar instead
 func (c *Config) RegisterStringSliceConfigVariable(
 	defaultValue []string, ptr *[]string, isHotReloadable bool, orderedKeys ...string,
@@ -550,6 +564,7 @@ func (c *Config) registerStringSliceVar(
 
 // RegisterStringMapConfigVariable registers string map config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterStringMapVar or RegisterReloadableStringMapVar instead
 func RegisterStringMapConfigVariable(
 	defaultValue map[string]interface{}, ptr *map[string]interface{}, isHotReloadable bool, orderedKeys ...string,
@@ -575,6 +590,7 @@ func RegisterReloadableStringMapVar(
 
 // RegisterStringMapConfigVariable registers string map config variable
 // WARNING: a different order of keys will result in a different variable
+//
 // Deprecated: use RegisterStringMapVar or RegisterReloadableStringMapVar instead
 func (c *Config) RegisterStringMapConfigVariable(
 	defaultValue map[string]interface{}, ptr *map[string]interface{}, isHotReloadable bool, orderedKeys ...string,

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -17,8 +17,8 @@ func RegisterIntVar(defaultValue int, ptr *int, valueScale int, keys ...string) 
 }
 
 // RegisterAtomicIntVar registers a hot-reloadable int config variable
-func RegisterAtomicIntVar(defaultValue int, ptr *Atomic[int], valueScale int, keys ...string) {
-	Default.RegisterAtomicIntVar(defaultValue, ptr, valueScale, keys...)
+func RegisterAtomicIntVar(defaultValue, valueScale int, keys ...string) *Atomic[int] {
+	return Default.RegisterAtomicIntVar(defaultValue, valueScale, keys...)
 }
 
 // RegisterIntConfigVariable registers int config variable
@@ -40,10 +40,12 @@ func (c *Config) RegisterIntVar(defaultValue int, ptr *int, valueScale int, keys
 
 // RegisterAtomicIntVar registers a hot-reloadable int config variable
 // Copy of RegisterIntConfigVariable, but with a way to avoid data races for hot reloadable config variables
-func (c *Config) RegisterAtomicIntVar(defaultValue int, ptr *Atomic[int], valueScale int, keys ...string) {
+func (c *Config) RegisterAtomicIntVar(defaultValue, valueScale int, keys ...string) *Atomic[int] {
+	ptr := getOrCreatePointer(c.atomicVars, &c.atomicVarsLock, defaultValue, keys...)
 	c.registerIntVar(defaultValue, ptr, true, valueScale, func(v int) {
 		ptr.store(v)
 	}, keys...)
+	return ptr
 }
 
 func (c *Config) registerIntVar(

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -15,8 +15,8 @@ func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool,
 
 // RegisterIntVar registers a not hot-reloadable int config variable
 // WARNING: a different order of keys will result in a different variable
-func RegisterIntVar(defaultValue int, ptr *int, valueScale int, orderedKeys ...string) {
-	Default.RegisterIntVar(defaultValue, ptr, valueScale, orderedKeys...)
+func RegisterIntVar(defaultValue int, valueScale int, orderedKeys ...string) *int {
+	return Default.RegisterIntVar(defaultValue, valueScale, orderedKeys...)
 }
 
 // RegisterReloadableIntVar registers a hot-reloadable int config variable
@@ -38,16 +38,18 @@ func (c *Config) RegisterIntConfigVariable(
 
 // RegisterIntVar registers a not hot-reloadable int config variable
 // WARNING: a different order of keys will result in a different variable
-func (c *Config) RegisterIntVar(defaultValue int, ptr *int, valueScale int, orderedKeys ...string) {
+func (c *Config) RegisterIntVar(defaultValue int, valueScale int, orderedKeys ...string) *int {
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*int)
 	c.registerIntVar(defaultValue, ptr, false, valueScale, func(v int) {
 		*ptr = v
 	}, orderedKeys...)
+	return ptr
 }
 
 // RegisterReloadableIntVar registers a hot-reloadable int config variable
 // WARNING: a different order of keys will result in a different variable
 func (c *Config) RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
-	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...)
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[int])
 	c.registerIntVar(defaultValue, ptr, true, valueScale, func(v int) {
 		ptr.store(v)
 	}, orderedKeys...)
@@ -90,8 +92,8 @@ func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bo
 
 // RegisterBoolVar registers a not hot-reloadable bool config variable
 // WARNING: a different order of keys will result in a different variable
-func RegisterBoolVar(defaultValue bool, ptr *bool, orderedKeys ...string) {
-	Default.RegisterBoolVar(defaultValue, ptr, orderedKeys...)
+func RegisterBoolVar(defaultValue bool, orderedKeys ...string) *bool {
+	return Default.RegisterBoolVar(defaultValue, orderedKeys...)
 }
 
 // RegisterReloadableBoolVar registers a hot-reloadable bool config variable
@@ -111,16 +113,18 @@ func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotR
 
 // RegisterBoolVar registers a not hot-reloadable bool config variable
 // WARNING: a different order of keys will result in a different variable
-func (c *Config) RegisterBoolVar(defaultValue bool, ptr *bool, orderedKeys ...string) {
+func (c *Config) RegisterBoolVar(defaultValue bool, orderedKeys ...string) *bool {
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*bool)
 	c.registerBoolVar(defaultValue, ptr, false, func(v bool) {
 		*ptr = v
 	}, orderedKeys...)
+	return ptr
 }
 
 // RegisterReloadableBoolVar registers a hot-reloadable bool config variable
 // WARNING: a different order of keys will result in a different variable
 func (c *Config) RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
-	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...)
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[bool])
 	c.registerBoolVar(defaultValue, ptr, true, func(v bool) {
 		ptr.store(v)
 	}, orderedKeys...)
@@ -161,8 +165,8 @@ func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotRelo
 
 // RegisterFloat64Var registers a not hot-reloadable float64 config variable
 // WARNING: a different order of keys will result in a different variable
-func RegisterFloat64Var(defaultValue float64, ptr *float64, orderedKeys ...string) {
-	Default.RegisterFloat64Var(defaultValue, ptr, orderedKeys...)
+func RegisterFloat64Var(defaultValue float64, orderedKeys ...string) *float64 {
+	return Default.RegisterFloat64Var(defaultValue, orderedKeys...)
 }
 
 // RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
@@ -182,16 +186,18 @@ func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float6
 
 // RegisterFloat64Var registers a not hot-reloadable float64 config variable
 // WARNING: a different order of keys will result in a different variable
-func (c *Config) RegisterFloat64Var(defaultValue float64, ptr *float64, orderedKeys ...string) {
+func (c *Config) RegisterFloat64Var(defaultValue float64, orderedKeys ...string) *float64 {
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*float64)
 	c.registerFloat64Var(defaultValue, ptr, false, func(v float64) {
 		*ptr = v
 	}, orderedKeys...)
+	return ptr
 }
 
 // RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
 // WARNING: a different order of keys will result in a different variable
 func (c *Config) RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
-	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...)
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[float64])
 	c.registerFloat64Var(defaultValue, ptr, true, func(v float64) {
 		ptr.store(v)
 	}, orderedKeys...)
@@ -235,8 +241,8 @@ func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable
 
 // RegisterInt64Var registers a not hot-reloadable int64 config variable
 // WARNING: a different order of keys will result in a different variable
-func RegisterInt64Var(defaultValue int64, ptr *int64, valueScale int64, orderedKeys ...string) {
-	Default.RegisterInt64Var(defaultValue, ptr, valueScale, orderedKeys...)
+func RegisterInt64Var(defaultValue int64, valueScale int64, orderedKeys ...string) *int64 {
+	return Default.RegisterInt64Var(defaultValue, valueScale, orderedKeys...)
 }
 
 // RegisterReloadableInt64Var registers a hot-reloadable int64 config variable
@@ -258,16 +264,18 @@ func (c *Config) RegisterInt64ConfigVariable(
 
 // RegisterInt64Var registers a not hot-reloadable int64 config variable
 // WARNING: a different order of keys will result in a different variable
-func (c *Config) RegisterInt64Var(defaultValue int64, ptr *int64, valueScale int64, orderedKeys ...string) {
+func (c *Config) RegisterInt64Var(defaultValue int64, valueScale int64, orderedKeys ...string) *int64 {
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*int64)
 	c.registerInt64Var(defaultValue, ptr, false, valueScale, func(v int64) {
 		*ptr = v
 	}, orderedKeys...)
+	return ptr
 }
 
 // RegisterReloadableInt64Var registers a not hot-reloadable int64 config variable
 // WARNING: a different order of keys will result in a different variable
 func (c *Config) RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
-	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...)
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[int64])
 	c.registerInt64Var(defaultValue, ptr, true, valueScale, func(v int64) {
 		ptr.store(v)
 	}, orderedKeys...)
@@ -314,9 +322,9 @@ func RegisterDurationConfigVariable(
 // RegisterDurationVar registers a not hot-reloadable duration config variable
 // WARNING: a different order of keys will result in a different variable
 func RegisterDurationVar(
-	defaultValueInTimescaleUnits int64, ptr *time.Duration, timeScale time.Duration, orderedKeys ...string,
-) {
-	Default.RegisterDurationVar(defaultValueInTimescaleUnits, ptr, timeScale, orderedKeys...)
+	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
+) *time.Duration {
+	return Default.RegisterDurationVar(defaultValueInTimescaleUnits, timeScale, orderedKeys...)
 }
 
 // RegisterReloadableDurationVar registers a not hot-reloadable duration config variable
@@ -339,11 +347,15 @@ func (c *Config) RegisterDurationConfigVariable(
 // RegisterDurationVar registers a not hot-reloadable duration config variable
 // WARNING: a different order of keys will result in a different variable
 func (c *Config) RegisterDurationVar(
-	defaultValueInTimescaleUnits int64, ptr *time.Duration, timeScale time.Duration, orderedKeys ...string,
-) {
+	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
+) *time.Duration {
+	ptr := getOrCreatePointer(
+		c.vars, c.varsMisuses, &c.varsLock, time.Duration(defaultValueInTimescaleUnits)*timeScale, false, orderedKeys...,
+	).(*time.Duration)
 	c.registerDurationVar(defaultValueInTimescaleUnits, ptr, false, timeScale, func(v time.Duration) {
 		*ptr = v
 	}, orderedKeys...)
+	return ptr
 }
 
 // RegisterReloadableDurationVar registers a hot-reloadable duration config variable
@@ -352,8 +364,8 @@ func (c *Config) RegisterReloadableDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
 ) *Reloadable[time.Duration] {
 	ptr := getOrCreatePointer(
-		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, time.Duration(defaultValueInTimescaleUnits), orderedKeys...,
-	)
+		c.vars, c.varsMisuses, &c.varsLock, time.Duration(defaultValueInTimescaleUnits)*timeScale, true, orderedKeys...,
+	).(*Reloadable[time.Duration])
 	c.registerDurationVar(defaultValueInTimescaleUnits, ptr, true, timeScale, func(v time.Duration) {
 		ptr.store(v)
 	}, orderedKeys...)
@@ -397,8 +409,8 @@ func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloada
 
 // RegisterStringVar registers a not hot-reloadable string config variable
 // WARNING: a different order of keys will result in a different variable
-func RegisterStringVar(defaultValue string, ptr *string, orderedKeys ...string) {
-	Default.RegisterStringVar(defaultValue, ptr, orderedKeys...)
+func RegisterStringVar(defaultValue string, orderedKeys ...string) *string {
+	return Default.RegisterStringVar(defaultValue, orderedKeys...)
 }
 
 // RegisterReloadableStringVar registers a hot-reloadable string config variable
@@ -418,16 +430,18 @@ func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, 
 
 // RegisterStringVar registers a not hot-reloadable string config variable
 // WARNING: a different order of keys will result in a different variable
-func (c *Config) RegisterStringVar(defaultValue string, ptr *string, orderedKeys ...string) {
+func (c *Config) RegisterStringVar(defaultValue string, orderedKeys ...string) *string {
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*string)
 	c.registerStringVar(defaultValue, ptr, false, func(v string) {
 		*ptr = v
 	}, orderedKeys...)
+	return ptr
 }
 
 // RegisterReloadableStringVar registers a hot-reloadable string config variable
 // WARNING: a different order of keys will result in a different variable
 func (c *Config) RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
-	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...)
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[string])
 	c.registerStringVar(defaultValue, ptr, true, func(v string) {
 		ptr.store(v)
 	}, orderedKeys...)
@@ -467,8 +481,8 @@ func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isH
 
 // RegisterStringSliceVar registers a not hot-reloadable string slice config variable
 // WARNING: a different order of keys will result in a different variable
-func RegisterStringSliceVar(defaultValue []string, ptr *[]string, orderedKeys ...string) {
-	Default.RegisterStringSliceVar(defaultValue, ptr, orderedKeys...)
+func RegisterStringSliceVar(defaultValue []string, orderedKeys ...string) *[]string {
+	return Default.RegisterStringSliceVar(defaultValue, orderedKeys...)
 }
 
 // RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
@@ -490,16 +504,18 @@ func (c *Config) RegisterStringSliceConfigVariable(
 
 // RegisterStringSliceVar registers a not hot-reloadable string slice config variable
 // WARNING: a different order of keys will result in a different variable
-func (c *Config) RegisterStringSliceVar(defaultValue []string, ptr *[]string, orderedKeys ...string) {
+func (c *Config) RegisterStringSliceVar(defaultValue []string, orderedKeys ...string) *[]string {
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*[]string)
 	c.registerStringSliceVar(defaultValue, ptr, false, func(v []string) {
 		*ptr = v
 	}, orderedKeys...)
+	return ptr
 }
 
 // RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
 // WARNING: a different order of keys will result in a different variable
 func (c *Config) RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
-	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...)
+	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[[]string])
 	c.registerStringSliceVar(defaultValue, ptr, true, func(v []string) {
 		ptr.store(v)
 	}, orderedKeys...)
@@ -544,9 +560,9 @@ func RegisterStringMapConfigVariable(
 // RegisterStringMapVar registers a not hot-reloadable string map config variable
 // WARNING: a different order of keys will result in a different variable
 func RegisterStringMapVar(
-	defaultValue map[string]interface{}, ptr *map[string]interface{}, orderedKeys ...string,
-) {
-	Default.RegisterStringMapVar(defaultValue, ptr, orderedKeys...)
+	defaultValue map[string]interface{}, orderedKeys ...string,
+) *map[string]interface{} {
+	return Default.RegisterStringMapVar(defaultValue, orderedKeys...)
 }
 
 // RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
@@ -570,12 +586,14 @@ func (c *Config) RegisterStringMapConfigVariable(
 
 // RegisterStringMapVar registers a not hot-reloadable string map config variable
 // WARNING: a different order of keys will result in a different variable
-func (c *Config) RegisterStringMapVar(
-	defaultValue map[string]interface{}, ptr *map[string]interface{}, orderedKeys ...string,
-) {
+func (c *Config) RegisterStringMapVar(defaultValue map[string]interface{}, orderedKeys ...string) *map[string]interface{} {
+	ptr := getOrCreatePointer(
+		c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...,
+	).(*map[string]interface{})
 	c.registerStringMapVar(defaultValue, ptr, false, func(v map[string]interface{}) {
 		*ptr = v
 	}, orderedKeys...)
+	return ptr
 }
 
 // RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
@@ -583,7 +601,9 @@ func (c *Config) RegisterStringMapVar(
 func (c *Config) RegisterReloadableStringMapVar(
 	defaultValue map[string]interface{}, orderedKeys ...string,
 ) *Reloadable[map[string]interface{}] {
-	ptr := getOrCreatePointer(c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...)
+	ptr := getOrCreatePointer(
+		c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...,
+	).(*Reloadable[map[string]interface{}])
 	c.registerStringMapVar(defaultValue, ptr, true, func(v map[string]interface{}) {
 		ptr.store(v)
 	}, orderedKeys...)

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -7,7 +7,8 @@ import (
 )
 
 // RegisterIntConfigVariable registers int config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterIntVar or RegisterReloadableIntVar instead
 func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, orderedKeys ...string) {
@@ -15,19 +16,22 @@ func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool,
 }
 
 // RegisterIntVar registers a not hot-reloadable int config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterIntVar(defaultValue, valueScale int, orderedKeys ...string) *int {
 	return Default.RegisterIntVar(defaultValue, valueScale, orderedKeys...)
 }
 
 // RegisterReloadableIntVar registers a hot-reloadable int config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
 	return Default.RegisterReloadableIntVar(defaultValue, valueScale, orderedKeys...)
 }
 
 // RegisterIntConfigVariable registers int config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterIntVar or RegisterReloadableIntVar instead
 func (c *Config) RegisterIntConfigVariable(
@@ -39,7 +43,8 @@ func (c *Config) RegisterIntConfigVariable(
 }
 
 // RegisterIntVar registers a not hot-reloadable int config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterIntVar(defaultValue, valueScale int, orderedKeys ...string) *int {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*int)
 	c.registerIntVar(defaultValue, ptr, false, valueScale, func(v int) {
@@ -49,7 +54,8 @@ func (c *Config) RegisterIntVar(defaultValue, valueScale int, orderedKeys ...str
 }
 
 // RegisterReloadableIntVar registers a hot-reloadable int config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[int])
 	c.registerIntVar(defaultValue, ptr, true, valueScale, func(v int) {
@@ -86,7 +92,8 @@ func (c *Config) registerIntVar(
 }
 
 // RegisterBoolConfigVariable registers bool config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterBoolVar or RegisterReloadableBoolVar instead
 func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, orderedKeys ...string) {
@@ -94,19 +101,22 @@ func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bo
 }
 
 // RegisterBoolVar registers a not hot-reloadable bool config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterBoolVar(defaultValue bool, orderedKeys ...string) *bool {
 	return Default.RegisterBoolVar(defaultValue, orderedKeys...)
 }
 
 // RegisterReloadableBoolVar registers a hot-reloadable bool config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
 	return Default.RegisterReloadableBoolVar(defaultValue, orderedKeys...)
 }
 
 // RegisterBoolConfigVariable registers bool config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterBoolVar or RegisterReloadableBoolVar instead
 func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, orderedKeys ...string) {
@@ -116,7 +126,8 @@ func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotR
 }
 
 // RegisterBoolVar registers a not hot-reloadable bool config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterBoolVar(defaultValue bool, orderedKeys ...string) *bool {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*bool)
 	c.registerBoolVar(defaultValue, ptr, false, func(v bool) {
@@ -126,7 +137,8 @@ func (c *Config) RegisterBoolVar(defaultValue bool, orderedKeys ...string) *bool
 }
 
 // RegisterReloadableBoolVar registers a hot-reloadable bool config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[bool])
 	c.registerBoolVar(defaultValue, ptr, true, func(v bool) {
@@ -161,7 +173,8 @@ func (c *Config) registerBoolVar(defaultValue bool, ptr any, isHotReloadable boo
 }
 
 // RegisterFloat64ConfigVariable registers float64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterFloat64Var or RegisterReloadableFloat64Var instead
 func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, orderedKeys ...string) {
@@ -169,19 +182,22 @@ func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotRelo
 }
 
 // RegisterFloat64Var registers a not hot-reloadable float64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterFloat64Var(defaultValue float64, orderedKeys ...string) *float64 {
 	return Default.RegisterFloat64Var(defaultValue, orderedKeys...)
 }
 
 // RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
 	return Default.RegisterReloadableFloat64Var(defaultValue, orderedKeys...)
 }
 
 // RegisterFloat64ConfigVariable registers float64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterFloat64Var or RegisterReloadableFloat64Var instead
 func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, orderedKeys ...string) {
@@ -191,7 +207,8 @@ func (c *Config) RegisterFloat64ConfigVariable(defaultValue float64, ptr *float6
 }
 
 // RegisterFloat64Var registers a not hot-reloadable float64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterFloat64Var(defaultValue float64, orderedKeys ...string) *float64 {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*float64)
 	c.registerFloat64Var(defaultValue, ptr, false, func(v float64) {
@@ -201,7 +218,8 @@ func (c *Config) RegisterFloat64Var(defaultValue float64, orderedKeys ...string)
 }
 
 // RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[float64])
 	c.registerFloat64Var(defaultValue, ptr, true, func(v float64) {
@@ -239,7 +257,8 @@ func (c *Config) registerFloat64Var(
 }
 
 // RegisterInt64ConfigVariable registers int64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterInt64Var or RegisterReloadableInt64Var instead
 func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, orderedKeys ...string) {
@@ -247,19 +266,22 @@ func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable
 }
 
 // RegisterInt64Var registers a not hot-reloadable int64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *int64 {
 	return Default.RegisterInt64Var(defaultValue, valueScale, orderedKeys...)
 }
 
 // RegisterReloadableInt64Var registers a hot-reloadable int64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
 	return Default.RegisterReloadableInt64Var(defaultValue, valueScale, orderedKeys...)
 }
 
 // RegisterInt64ConfigVariable registers int64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterInt64Var or RegisterReloadableInt64Var instead
 func (c *Config) RegisterInt64ConfigVariable(
@@ -271,7 +293,8 @@ func (c *Config) RegisterInt64ConfigVariable(
 }
 
 // RegisterInt64Var registers a not hot-reloadable int64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *int64 {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*int64)
 	c.registerInt64Var(defaultValue, ptr, false, valueScale, func(v int64) {
@@ -281,7 +304,8 @@ func (c *Config) RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ..
 }
 
 // RegisterReloadableInt64Var registers a not hot-reloadable int64 config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[int64])
 	c.registerInt64Var(defaultValue, ptr, true, valueScale, func(v int64) {
@@ -319,7 +343,8 @@ func (c *Config) registerInt64Var(
 }
 
 // RegisterDurationConfigVariable registers duration config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterDurationVar or RegisterReloadableDurationVar instead
 func RegisterDurationConfigVariable(
@@ -329,7 +354,8 @@ func RegisterDurationConfigVariable(
 }
 
 // RegisterDurationVar registers a not hot-reloadable duration config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
 ) *time.Duration {
@@ -337,13 +363,15 @@ func RegisterDurationVar(
 }
 
 // RegisterReloadableDurationVar registers a not hot-reloadable duration config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableDurationVar(defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string) *Reloadable[time.Duration] {
 	return Default.RegisterReloadableDurationVar(defaultValueInTimescaleUnits, timeScale, orderedKeys...)
 }
 
 // RegisterDurationConfigVariable registers duration config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterDurationVar or RegisterReloadableDurationVar instead
 func (c *Config) RegisterDurationConfigVariable(
@@ -355,7 +383,8 @@ func (c *Config) RegisterDurationConfigVariable(
 }
 
 // RegisterDurationVar registers a not hot-reloadable duration config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
 ) *time.Duration {
@@ -369,7 +398,8 @@ func (c *Config) RegisterDurationVar(
 }
 
 // RegisterReloadableDurationVar registers a hot-reloadable duration config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
 ) *Reloadable[time.Duration] {
@@ -411,7 +441,8 @@ func (c *Config) registerDurationVar(
 }
 
 // RegisterStringConfigVariable registers string config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterStringVar or RegisterReloadableStringVar instead
 func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, orderedKeys ...string) {
@@ -419,19 +450,22 @@ func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloada
 }
 
 // RegisterStringVar registers a not hot-reloadable string config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterStringVar(defaultValue string, orderedKeys ...string) *string {
 	return Default.RegisterStringVar(defaultValue, orderedKeys...)
 }
 
 // RegisterReloadableStringVar registers a hot-reloadable string config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
 	return Default.RegisterReloadableStringVar(defaultValue, orderedKeys...)
 }
 
 // RegisterStringConfigVariable registers string config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterStringVar or RegisterReloadableStringVar instead
 func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, orderedKeys ...string) {
@@ -441,7 +475,8 @@ func (c *Config) RegisterStringConfigVariable(defaultValue string, ptr *string, 
 }
 
 // RegisterStringVar registers a not hot-reloadable string config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterStringVar(defaultValue string, orderedKeys ...string) *string {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*string)
 	c.registerStringVar(defaultValue, ptr, false, func(v string) {
@@ -451,7 +486,8 @@ func (c *Config) RegisterStringVar(defaultValue string, orderedKeys ...string) *
 }
 
 // RegisterReloadableStringVar registers a hot-reloadable string config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[string])
 	c.registerStringVar(defaultValue, ptr, true, func(v string) {
@@ -485,7 +521,8 @@ func (c *Config) registerStringVar(defaultValue string, ptr any, isHotReloadable
 }
 
 // RegisterStringSliceConfigVariable registers string slice config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterStringSliceVar or RegisterReloadableStringSliceVar instead
 func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isHotReloadable bool, orderedKeys ...string) {
@@ -493,19 +530,22 @@ func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isH
 }
 
 // RegisterStringSliceVar registers a not hot-reloadable string slice config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterStringSliceVar(defaultValue []string, orderedKeys ...string) *[]string {
 	return Default.RegisterStringSliceVar(defaultValue, orderedKeys...)
 }
 
 // RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
 	return Default.RegisterReloadableStringSliceVar(defaultValue, orderedKeys...)
 }
 
 // RegisterStringSliceConfigVariable registers string slice config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterStringSliceVar or RegisterReloadableStringSliceVar instead
 func (c *Config) RegisterStringSliceConfigVariable(
@@ -517,7 +557,8 @@ func (c *Config) RegisterStringSliceConfigVariable(
 }
 
 // RegisterStringSliceVar registers a not hot-reloadable string slice config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterStringSliceVar(defaultValue []string, orderedKeys ...string) *[]string {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...).(*[]string)
 	c.registerStringSliceVar(defaultValue, ptr, false, func(v []string) {
@@ -527,7 +568,8 @@ func (c *Config) RegisterStringSliceVar(defaultValue []string, orderedKeys ...st
 }
 
 // RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
 	ptr := getOrCreatePointer(c.vars, c.varsMisuses, &c.varsLock, defaultValue, true, orderedKeys...).(*Reloadable[[]string])
 	c.registerStringSliceVar(defaultValue, ptr, true, func(v []string) {
@@ -563,7 +605,8 @@ func (c *Config) registerStringSliceVar(
 }
 
 // RegisterStringMapConfigVariable registers string map config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterStringMapVar or RegisterReloadableStringMapVar instead
 func RegisterStringMapConfigVariable(
@@ -573,7 +616,8 @@ func RegisterStringMapConfigVariable(
 }
 
 // RegisterStringMapVar registers a not hot-reloadable string map config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterStringMapVar(
 	defaultValue map[string]interface{}, orderedKeys ...string,
 ) *map[string]interface{} {
@@ -581,7 +625,8 @@ func RegisterStringMapVar(
 }
 
 // RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func RegisterReloadableStringMapVar(
 	defaultValue map[string]interface{}, orderedKeys ...string,
 ) *Reloadable[map[string]interface{}] {
@@ -589,7 +634,8 @@ func RegisterReloadableStringMapVar(
 }
 
 // RegisterStringMapConfigVariable registers string map config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
 // Deprecated: use RegisterStringMapVar or RegisterReloadableStringMapVar instead
 func (c *Config) RegisterStringMapConfigVariable(
@@ -601,7 +647,8 @@ func (c *Config) RegisterStringMapConfigVariable(
 }
 
 // RegisterStringMapVar registers a not hot-reloadable string map config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterStringMapVar(defaultValue map[string]interface{}, orderedKeys ...string) *map[string]interface{} {
 	ptr := getOrCreatePointer(
 		c.vars, c.varsMisuses, &c.varsLock, defaultValue, false, orderedKeys...,
@@ -613,7 +660,8 @@ func (c *Config) RegisterStringMapVar(defaultValue map[string]interface{}, order
 }
 
 // RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
-// WARNING: a different order of keys will result in a different variable
+// WARNING: keys are being looked up in requested order and the value of the first found key is returned,
+// e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) RegisterReloadableStringMapVar(
 	defaultValue map[string]interface{}, orderedKeys ...string,
 ) *Reloadable[map[string]interface{}] {

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -341,8 +341,12 @@ type Atomic[T any] struct {
 	atomic.Value
 }
 
-func (a *Atomic[T]) Load() T {
-	return a.Value.Load().(T)
+func (a *Atomic[T]) Load() (zero T) {
+	v := a.Value.Load()
+	if v == nil {
+		return zero
+	}
+	return v.(T)
 }
 
 func (a *Atomic[T]) Store(v T) {

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -340,14 +340,15 @@ func (c *Config) appendVarToConfigMaps(key string, configVar *configValue) {
 // Atomic is used as a wrapper for hot-reloadable config variables
 type Atomic[T comparable] struct {
 	value T
-	lock  sync.Mutex
+	lock  sync.RWMutex
 }
 
 // Load should be used to read the underlying value without worrying about data races
 func (a *Atomic[T]) Load() T {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-	return a.value
+	a.lock.RLock()
+	v := a.value
+	a.lock.RUnlock()
+	return v
 }
 
 // Store should be used to write a value without worrying about data races

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -11,25 +11,25 @@ import (
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterIntVar or RegisterReloadableIntVar instead
+// Deprecated: use GetIntVar or GetReloadableIntVar instead
 func RegisterIntConfigVariable(defaultValue int, ptr *int, isHotReloadable bool, valueScale int, orderedKeys ...string) {
 	Default.RegisterIntConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, orderedKeys...)
 }
 
-// RegisterIntVar registers a not hot-reloadable int config variable
+// GetIntVar registers a not hot-reloadable int config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterIntVar(defaultValue, valueScale int, orderedKeys ...string) int {
-	return Default.RegisterIntVar(defaultValue, valueScale, orderedKeys...)
+func GetIntVar(defaultValue, valueScale int, orderedKeys ...string) int {
+	return Default.GetIntVar(defaultValue, valueScale, orderedKeys...)
 }
 
-// RegisterReloadableIntVar registers a hot-reloadable int config variable
+// GetReloadableIntVar registers a hot-reloadable int config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
-	return Default.RegisterReloadableIntVar(defaultValue, valueScale, orderedKeys...)
+func GetReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
+	return Default.GetReloadableIntVar(defaultValue, valueScale, orderedKeys...)
 }
 
 // RegisterIntConfigVariable registers int config variable
@@ -37,7 +37,7 @@ func RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...strin
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterIntVar or RegisterReloadableIntVar instead
+// Deprecated: use GetIntVar or GetReloadableIntVar instead
 func (c *Config) RegisterIntConfigVariable(
 	defaultValue int, ptr *int, isHotReloadable bool, valueScale int, orderedKeys ...string,
 ) {
@@ -46,11 +46,11 @@ func (c *Config) RegisterIntConfigVariable(
 	}, orderedKeys...)
 }
 
-// RegisterIntVar registers a not hot-reloadable int config variable
+// GetIntVar registers a not hot-reloadable int config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterIntVar(defaultValue, valueScale int, orderedKeys ...string) int {
+func (c *Config) GetIntVar(defaultValue, valueScale int, orderedKeys ...string) int {
 	var ret int
 	c.registerIntVar(defaultValue, nil, false, valueScale, func(v int) {
 		ret = v
@@ -58,11 +58,11 @@ func (c *Config) RegisterIntVar(defaultValue, valueScale int, orderedKeys ...str
 	return ret
 }
 
-// RegisterReloadableIntVar registers a hot-reloadable int config variable
+// GetReloadableIntVar registers a hot-reloadable int config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
+func (c *Config) GetReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
 	ptr := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue*valueScale, orderedKeys...,
 	)
@@ -104,25 +104,25 @@ func (c *Config) registerIntVar(
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterBoolVar or RegisterReloadableBoolVar instead
+// Deprecated: use GetBoolVar or GetReloadableBoolVar instead
 func RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, orderedKeys ...string) {
 	Default.RegisterBoolConfigVariable(defaultValue, ptr, isHotReloadable, orderedKeys...)
 }
 
-// RegisterBoolVar registers a not hot-reloadable bool config variable
+// GetBoolVar registers a not hot-reloadable bool config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterBoolVar(defaultValue bool, orderedKeys ...string) bool {
-	return Default.RegisterBoolVar(defaultValue, orderedKeys...)
+func GetBoolVar(defaultValue bool, orderedKeys ...string) bool {
+	return Default.GetBoolVar(defaultValue, orderedKeys...)
 }
 
-// RegisterReloadableBoolVar registers a hot-reloadable bool config variable
+// GetReloadableBoolVar registers a hot-reloadable bool config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
-	return Default.RegisterReloadableBoolVar(defaultValue, orderedKeys...)
+func GetReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
+	return Default.GetReloadableBoolVar(defaultValue, orderedKeys...)
 }
 
 // RegisterBoolConfigVariable registers bool config variable
@@ -130,18 +130,18 @@ func RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reload
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterBoolVar or RegisterReloadableBoolVar instead
+// Deprecated: use GetBoolVar or GetReloadableBoolVar instead
 func (c *Config) RegisterBoolConfigVariable(defaultValue bool, ptr *bool, isHotReloadable bool, orderedKeys ...string) {
 	c.registerBoolVar(defaultValue, ptr, isHotReloadable, func(v bool) {
 		*ptr = v
 	}, orderedKeys...)
 }
 
-// RegisterBoolVar registers a not hot-reloadable bool config variable
+// GetBoolVar registers a not hot-reloadable bool config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterBoolVar(defaultValue bool, orderedKeys ...string) bool {
+func (c *Config) GetBoolVar(defaultValue bool, orderedKeys ...string) bool {
 	var ret bool
 	c.registerBoolVar(defaultValue, nil, false, func(v bool) {
 		ret = v
@@ -149,11 +149,11 @@ func (c *Config) RegisterBoolVar(defaultValue bool, orderedKeys ...string) bool 
 	return ret
 }
 
-// RegisterReloadableBoolVar registers a hot-reloadable bool config variable
+// GetReloadableBoolVar registers a hot-reloadable bool config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
+func (c *Config) GetReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
 	ptr := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...,
 	)
@@ -193,25 +193,25 @@ func (c *Config) registerBoolVar(defaultValue bool, ptr any, isHotReloadable boo
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterFloat64Var or RegisterReloadableFloat64Var instead
+// Deprecated: use GetFloat64Var or GetReloadableFloat64Var instead
 func RegisterFloat64ConfigVariable(defaultValue float64, ptr *float64, isHotReloadable bool, orderedKeys ...string) {
 	Default.RegisterFloat64ConfigVariable(defaultValue, ptr, isHotReloadable, orderedKeys...)
 }
 
-// RegisterFloat64Var registers a not hot-reloadable float64 config variable
+// GetFloat64Var registers a not hot-reloadable float64 config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterFloat64Var(defaultValue float64, orderedKeys ...string) float64 {
-	return Default.RegisterFloat64Var(defaultValue, orderedKeys...)
+func GetFloat64Var(defaultValue float64, orderedKeys ...string) float64 {
+	return Default.GetFloat64Var(defaultValue, orderedKeys...)
 }
 
-// RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
+// GetReloadableFloat64Var registers a hot-reloadable float64 config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
-	return Default.RegisterReloadableFloat64Var(defaultValue, orderedKeys...)
+func GetReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
+	return Default.GetReloadableFloat64Var(defaultValue, orderedKeys...)
 }
 
 // RegisterFloat64ConfigVariable registers float64 config variable
@@ -219,7 +219,7 @@ func RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterFloat64Var or RegisterReloadableFloat64Var instead
+// Deprecated: use GetFloat64Var or GetReloadableFloat64Var instead
 func (c *Config) RegisterFloat64ConfigVariable(
 	defaultValue float64, ptr *float64, isHotReloadable bool, orderedKeys ...string,
 ) {
@@ -228,11 +228,11 @@ func (c *Config) RegisterFloat64ConfigVariable(
 	}, orderedKeys...)
 }
 
-// RegisterFloat64Var registers a not hot-reloadable float64 config variable
+// GetFloat64Var registers a not hot-reloadable float64 config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterFloat64Var(defaultValue float64, orderedKeys ...string) float64 {
+func (c *Config) GetFloat64Var(defaultValue float64, orderedKeys ...string) float64 {
 	var ret float64
 	c.registerFloat64Var(defaultValue, nil, false, func(v float64) {
 		ret = v
@@ -240,11 +240,11 @@ func (c *Config) RegisterFloat64Var(defaultValue float64, orderedKeys ...string)
 	return ret
 }
 
-// RegisterReloadableFloat64Var registers a hot-reloadable float64 config variable
+// GetReloadableFloat64Var registers a hot-reloadable float64 config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
+func (c *Config) GetReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
 	ptr := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...,
 	)
@@ -287,25 +287,25 @@ func (c *Config) registerFloat64Var(
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterInt64Var or RegisterReloadableInt64Var instead
+// Deprecated: use GetInt64Var or GetReloadableInt64Var instead
 func RegisterInt64ConfigVariable(defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, orderedKeys ...string) {
 	Default.RegisterInt64ConfigVariable(defaultValue, ptr, isHotReloadable, valueScale, orderedKeys...)
 }
 
-// RegisterInt64Var registers a not hot-reloadable int64 config variable
+// GetInt64Var registers a not hot-reloadable int64 config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ...string) int64 {
-	return Default.RegisterInt64Var(defaultValue, valueScale, orderedKeys...)
+func GetInt64Var(defaultValue, valueScale int64, orderedKeys ...string) int64 {
+	return Default.GetInt64Var(defaultValue, valueScale, orderedKeys...)
 }
 
-// RegisterReloadableInt64Var registers a hot-reloadable int64 config variable
+// GetReloadableInt64Var registers a hot-reloadable int64 config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
-	return Default.RegisterReloadableInt64Var(defaultValue, valueScale, orderedKeys...)
+func GetReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
+	return Default.GetReloadableInt64Var(defaultValue, valueScale, orderedKeys...)
 }
 
 // RegisterInt64ConfigVariable registers int64 config variable
@@ -313,7 +313,7 @@ func RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...s
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterInt64Var or RegisterReloadableInt64Var instead
+// Deprecated: use GetInt64Var or GetReloadableInt64Var instead
 func (c *Config) RegisterInt64ConfigVariable(
 	defaultValue int64, ptr *int64, isHotReloadable bool, valueScale int64, orderedKeys ...string,
 ) {
@@ -322,11 +322,11 @@ func (c *Config) RegisterInt64ConfigVariable(
 	}, orderedKeys...)
 }
 
-// RegisterInt64Var registers a not hot-reloadable int64 config variable
+// GetInt64Var registers a not hot-reloadable int64 config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ...string) int64 {
+func (c *Config) GetInt64Var(defaultValue, valueScale int64, orderedKeys ...string) int64 {
 	var ret int64
 	c.registerInt64Var(defaultValue, nil, false, valueScale, func(v int64) {
 		ret = v
@@ -334,11 +334,11 @@ func (c *Config) RegisterInt64Var(defaultValue, valueScale int64, orderedKeys ..
 	return ret
 }
 
-// RegisterReloadableInt64Var registers a not hot-reloadable int64 config variable
+// GetReloadableInt64Var registers a not hot-reloadable int64 config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
+func (c *Config) GetReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
 	ptr := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue*valueScale, orderedKeys...,
 	)
@@ -381,29 +381,29 @@ func (c *Config) registerInt64Var(
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterDurationVar or RegisterReloadableDurationVar instead
+// Deprecated: use GetDurationVar or GetReloadableDurationVar instead
 func RegisterDurationConfigVariable(
 	defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, orderedKeys ...string,
 ) {
 	Default.RegisterDurationConfigVariable(defaultValueInTimescaleUnits, ptr, isHotReloadable, timeScale, orderedKeys...)
 }
 
-// RegisterDurationVar registers a not hot-reloadable duration config variable
+// GetDurationVar registers a not hot-reloadable duration config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterDurationVar(
+func GetDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
 ) time.Duration {
-	return Default.RegisterDurationVar(defaultValueInTimescaleUnits, timeScale, orderedKeys...)
+	return Default.GetDurationVar(defaultValueInTimescaleUnits, timeScale, orderedKeys...)
 }
 
-// RegisterReloadableDurationVar registers a not hot-reloadable duration config variable
+// GetReloadableDurationVar registers a not hot-reloadable duration config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterReloadableDurationVar(defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string) *Reloadable[time.Duration] {
-	return Default.RegisterReloadableDurationVar(defaultValueInTimescaleUnits, timeScale, orderedKeys...)
+func GetReloadableDurationVar(defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string) *Reloadable[time.Duration] {
+	return Default.GetReloadableDurationVar(defaultValueInTimescaleUnits, timeScale, orderedKeys...)
 }
 
 // RegisterDurationConfigVariable registers duration config variable
@@ -411,7 +411,7 @@ func RegisterReloadableDurationVar(defaultValueInTimescaleUnits int64, timeScale
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterDurationVar or RegisterReloadableDurationVar instead
+// Deprecated: use GetDurationVar or GetReloadableDurationVar instead
 func (c *Config) RegisterDurationConfigVariable(
 	defaultValueInTimescaleUnits int64, ptr *time.Duration, isHotReloadable bool, timeScale time.Duration, orderedKeys ...string,
 ) {
@@ -420,11 +420,11 @@ func (c *Config) RegisterDurationConfigVariable(
 	}, orderedKeys...)
 }
 
-// RegisterDurationVar registers a not hot-reloadable duration config variable
+// GetDurationVar registers a not hot-reloadable duration config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterDurationVar(
+func (c *Config) GetDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
 ) time.Duration {
 	var ret time.Duration
@@ -434,11 +434,11 @@ func (c *Config) RegisterDurationVar(
 	return ret
 }
 
-// RegisterReloadableDurationVar registers a hot-reloadable duration config variable
+// GetReloadableDurationVar registers a hot-reloadable duration config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterReloadableDurationVar(
+func (c *Config) GetReloadableDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
 ) *Reloadable[time.Duration] {
 	ptr := getOrCreatePointer(
@@ -484,25 +484,25 @@ func (c *Config) registerDurationVar(
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterStringVar or RegisterReloadableStringVar instead
+// Deprecated: use GetStringVar or GetReloadableStringVar instead
 func RegisterStringConfigVariable(defaultValue string, ptr *string, isHotReloadable bool, orderedKeys ...string) {
 	Default.RegisterStringConfigVariable(defaultValue, ptr, isHotReloadable, orderedKeys...)
 }
 
-// RegisterStringVar registers a not hot-reloadable string config variable
+// GetStringVar registers a not hot-reloadable string config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterStringVar(defaultValue string, orderedKeys ...string) string {
-	return Default.RegisterStringVar(defaultValue, orderedKeys...)
+func GetStringVar(defaultValue string, orderedKeys ...string) string {
+	return Default.GetStringVar(defaultValue, orderedKeys...)
 }
 
-// RegisterReloadableStringVar registers a hot-reloadable string config variable
+// GetReloadableStringVar registers a hot-reloadable string config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
-	return Default.RegisterReloadableStringVar(defaultValue, orderedKeys...)
+func GetReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
+	return Default.GetReloadableStringVar(defaultValue, orderedKeys...)
 }
 
 // RegisterStringConfigVariable registers string config variable
@@ -510,7 +510,7 @@ func RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Re
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterStringVar or RegisterReloadableStringVar instead
+// Deprecated: use GetStringVar or GetReloadableStringVar instead
 func (c *Config) RegisterStringConfigVariable(
 	defaultValue string, ptr *string, isHotReloadable bool, orderedKeys ...string,
 ) {
@@ -519,11 +519,11 @@ func (c *Config) RegisterStringConfigVariable(
 	}, orderedKeys...)
 }
 
-// RegisterStringVar registers a not hot-reloadable string config variable
+// GetStringVar registers a not hot-reloadable string config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterStringVar(defaultValue string, orderedKeys ...string) string {
+func (c *Config) GetStringVar(defaultValue string, orderedKeys ...string) string {
 	var ret string
 	c.registerStringVar(defaultValue, nil, false, func(v string) {
 		ret = v
@@ -531,11 +531,11 @@ func (c *Config) RegisterStringVar(defaultValue string, orderedKeys ...string) s
 	return ret
 }
 
-// RegisterReloadableStringVar registers a hot-reloadable string config variable
+// GetReloadableStringVar registers a hot-reloadable string config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
+func (c *Config) GetReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
 	ptr := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...,
 	)
@@ -576,25 +576,25 @@ func (c *Config) registerStringVar(
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterStringSliceVar or RegisterReloadableStringSliceVar instead
+// Deprecated: use GetStringSliceVar or GetReloadableStringSliceVar instead
 func RegisterStringSliceConfigVariable(defaultValue []string, ptr *[]string, isHotReloadable bool, orderedKeys ...string) {
 	Default.RegisterStringSliceConfigVariable(defaultValue, ptr, isHotReloadable, orderedKeys...)
 }
 
-// RegisterStringSliceVar registers a not hot-reloadable string slice config variable
+// GetStringSliceVar registers a not hot-reloadable string slice config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterStringSliceVar(defaultValue []string, orderedKeys ...string) []string {
-	return Default.RegisterStringSliceVar(defaultValue, orderedKeys...)
+func GetStringSliceVar(defaultValue []string, orderedKeys ...string) []string {
+	return Default.GetStringSliceVar(defaultValue, orderedKeys...)
 }
 
-// RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
+// GetReloadableStringSliceVar registers a hot-reloadable string slice config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
-	return Default.RegisterReloadableStringSliceVar(defaultValue, orderedKeys...)
+func GetReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
+	return Default.GetReloadableStringSliceVar(defaultValue, orderedKeys...)
 }
 
 // RegisterStringSliceConfigVariable registers string slice config variable
@@ -602,7 +602,7 @@ func RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...stri
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterStringSliceVar or RegisterReloadableStringSliceVar instead
+// Deprecated: use GetStringSliceVar or GetReloadableStringSliceVar instead
 func (c *Config) RegisterStringSliceConfigVariable(
 	defaultValue []string, ptr *[]string, isHotReloadable bool, orderedKeys ...string,
 ) {
@@ -611,11 +611,11 @@ func (c *Config) RegisterStringSliceConfigVariable(
 	}, orderedKeys...)
 }
 
-// RegisterStringSliceVar registers a not hot-reloadable string slice config variable
+// GetStringSliceVar registers a not hot-reloadable string slice config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterStringSliceVar(defaultValue []string, orderedKeys ...string) []string {
+func (c *Config) GetStringSliceVar(defaultValue []string, orderedKeys ...string) []string {
 	var ret []string
 	c.registerStringSliceVar(defaultValue, ret, false, func(v []string) {
 		ret = v
@@ -623,11 +623,11 @@ func (c *Config) RegisterStringSliceVar(defaultValue []string, orderedKeys ...st
 	return ret
 }
 
-// RegisterReloadableStringSliceVar registers a hot-reloadable string slice config variable
+// GetReloadableStringSliceVar registers a hot-reloadable string slice config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
+func (c *Config) GetReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
 	ptr := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...,
 	)
@@ -668,29 +668,29 @@ func (c *Config) registerStringSliceVar(
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterStringMapVar or RegisterReloadableStringMapVar instead
+// Deprecated: use GetStringMapVar or GetReloadableStringMapVar instead
 func RegisterStringMapConfigVariable(
 	defaultValue map[string]interface{}, ptr *map[string]interface{}, isHotReloadable bool, orderedKeys ...string,
 ) {
 	Default.RegisterStringMapConfigVariable(defaultValue, ptr, isHotReloadable, orderedKeys...)
 }
 
-// RegisterStringMapVar registers a not hot-reloadable string map config variable
+// GetStringMapVar registers a not hot-reloadable string map config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterStringMapVar(defaultValue map[string]interface{}, orderedKeys ...string) map[string]interface{} {
-	return Default.RegisterStringMapVar(defaultValue, orderedKeys...)
+func GetStringMapVar(defaultValue map[string]interface{}, orderedKeys ...string) map[string]interface{} {
+	return Default.GetStringMapVar(defaultValue, orderedKeys...)
 }
 
-// RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
+// GetReloadableStringMapVar registers a hot-reloadable string map config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func RegisterReloadableStringMapVar(
+func GetReloadableStringMapVar(
 	defaultValue map[string]interface{}, orderedKeys ...string,
 ) *Reloadable[map[string]interface{}] {
-	return Default.RegisterReloadableStringMapVar(defaultValue, orderedKeys...)
+	return Default.GetReloadableStringMapVar(defaultValue, orderedKeys...)
 }
 
 // RegisterStringMapConfigVariable registers string map config variable
@@ -698,7 +698,7 @@ func RegisterReloadableStringMapVar(
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 //
-// Deprecated: use RegisterStringMapVar or RegisterReloadableStringMapVar instead
+// Deprecated: use GetStringMapVar or GetReloadableStringMapVar instead
 func (c *Config) RegisterStringMapConfigVariable(
 	defaultValue map[string]interface{}, ptr *map[string]interface{}, isHotReloadable bool, orderedKeys ...string,
 ) {
@@ -707,11 +707,11 @@ func (c *Config) RegisterStringMapConfigVariable(
 	}, orderedKeys...)
 }
 
-// RegisterStringMapVar registers a not hot-reloadable string map config variable
+// GetStringMapVar registers a not hot-reloadable string map config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterStringMapVar(
+func (c *Config) GetStringMapVar(
 	defaultValue map[string]interface{}, orderedKeys ...string,
 ) map[string]interface{} {
 	var ret map[string]interface{}
@@ -721,11 +721,11 @@ func (c *Config) RegisterStringMapVar(
 	return ret
 }
 
-// RegisterReloadableStringMapVar registers a hot-reloadable string map config variable
+// GetReloadableStringMapVar registers a hot-reloadable string map config variable
 //
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
-func (c *Config) RegisterReloadableStringMapVar(
+func (c *Config) GetReloadableStringMapVar(
 	defaultValue map[string]interface{}, orderedKeys ...string,
 ) *Reloadable[map[string]interface{}] {
 	ptr := getOrCreatePointer(

--- a/config/load.go
+++ b/config/load.go
@@ -60,7 +60,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 		for _, configVal := range configValArr {
 			value := configVal.value
 			switch value := value.(type) {
-			case *int, *Atomic[int]:
+			case *int, *Reloadable[int]:
 				var _value int
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -75,7 +75,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				}
 				_value = _value * configVal.multiplier.(int)
 				swapHotReloadableConfig(key, "%d", configVal, value, _value, compare[int]())
-			case *int64, *Atomic[int64]:
+			case *int64, *Reloadable[int64]:
 				var _value int64
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -90,7 +90,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				}
 				_value = _value * configVal.multiplier.(int64)
 				swapHotReloadableConfig(key, "%d", configVal, value, _value, compare[int64]())
-			case *string, *Atomic[string]:
+			case *string, *Reloadable[string]:
 				var _value string
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -104,7 +104,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 					_value = configVal.defaultValue.(string)
 				}
 				swapHotReloadableConfig(key, "%q", configVal, value, _value, compare[string]())
-			case *time.Duration, *Atomic[time.Duration]:
+			case *time.Duration, *Reloadable[time.Duration]:
 				var _value time.Duration
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -118,7 +118,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 					_value = time.Duration(configVal.defaultValue.(int64)) * configVal.multiplier.(time.Duration)
 				}
 				swapHotReloadableConfig(key, "%d", configVal, value, _value, compare[time.Duration]())
-			case *bool, *Atomic[bool]:
+			case *bool, *Reloadable[bool]:
 				var _value bool
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -132,7 +132,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 					_value = configVal.defaultValue.(bool)
 				}
 				swapHotReloadableConfig(key, "%v", configVal, value, _value, compare[bool]())
-			case *float64, *Atomic[float64]:
+			case *float64, *Reloadable[float64]:
 				var _value float64
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -147,7 +147,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				}
 				_value = _value * configVal.multiplier.(float64)
 				swapHotReloadableConfig(key, "%v", configVal, value, _value, compare[float64]())
-			case *[]string, *Atomic[[]string]:
+			case *[]string, *Reloadable[[]string]:
 				var _value []string
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -163,7 +163,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				swapHotReloadableConfig(key, "%v", configVal, value, _value, func(a, b []string) bool {
 					return slices.Compare(a, b) == 0
 				})
-			case *map[string]interface{}, *Atomic[map[string]interface{}]:
+			case *map[string]interface{}, *Reloadable[map[string]interface{}]:
 				var _value map[string]interface{}
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -197,8 +197,8 @@ func swapHotReloadableConfig[T configTypes](
 		}
 		return
 	}
-	atomicValue, _ := configVal.value.(*Atomic[T])
-	if oldValue, swapped := atomicValue.swapIfNotEqual(newValue, compare); swapped {
+	reloadableValue, _ := configVal.value.(*Reloadable[T])
+	if oldValue, swapped := reloadableValue.swapIfNotEqual(newValue, compare); swapped {
 		fmt.Printf("The value of key %q & variable %p changed from "+placeholder+" to "+placeholder+"\n",
 			key, configVal, oldValue, newValue,
 		)

--- a/config/load.go
+++ b/config/load.go
@@ -184,7 +184,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 	}
 }
 
-func swapHotReloadableConfig[T any](
+func swapHotReloadableConfig[T configTypes](
 	key, placeholder string, configVal *configValue, ptr any, newValue T,
 	compare func(T, T) bool,
 ) {

--- a/config/load.go
+++ b/config/load.go
@@ -138,7 +138,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 					_value = configVal.defaultValue.(bool)
 				}
 				swapHotReloadableConfig(key, "%v", configVal, value, _value)
-			case *float64:
+			case *float64, *Atomic[float64]:
 				var _value float64
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -152,10 +152,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 					_value = configVal.defaultValue.(float64)
 				}
 				_value = _value * configVal.multiplier.(float64)
-				if _value != *value {
-					fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
-					*value = _value
-				}
+				swapHotReloadableConfig(key, "%v", configVal, value, _value)
 			case *[]string:
 				var _value []string
 				var isSet bool

--- a/config/load.go
+++ b/config/load.go
@@ -90,7 +90,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				}
 				_value = _value * configVal.multiplier.(int64)
 				swapHotReloadableConfig(key, "%d", configVal, value, _value)
-			case *string:
+			case *string, *Atomic[string]:
 				var _value string
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -103,10 +103,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				if !isSet {
 					_value = configVal.defaultValue.(string)
 				}
-				if _value != *value {
-					fmt.Printf("The value of key:%s & variable:%p changed from %v to %v\n", key, configVal, *value, _value)
-					*value = _value
-				}
+				swapHotReloadableConfig(key, "%q", configVal, value, _value)
 			case *time.Duration, *Atomic[time.Duration]:
 				var _value time.Duration
 				var isSet bool

--- a/config/load.go
+++ b/config/load.go
@@ -83,12 +83,10 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 					}
 				} else {
 					atomicValue := configVal.value.(*Atomic[int])
-					if intValue := atomicValue.Load(); _value != intValue {
-						if atomicValue.CompareAndSwap(intValue, _value) {
-							fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n",
-								key, configVal, intValue, _value,
-							)
-						}
+					if oldValue, swapped := atomicValue.swapIfNotEqual(_value); swapped {
+						fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n",
+							key, configVal, oldValue, _value,
+						)
 					}
 				}
 			case *int64:
@@ -148,12 +146,10 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 					}
 				} else {
 					atomicValue := configVal.value.(*Atomic[time.Duration])
-					if intValue := atomicValue.Load(); _value != intValue {
-						if atomicValue.CompareAndSwap(intValue, _value) {
-							fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n",
-								key, configVal, intValue, _value,
-							)
-						}
+					if oldValue, swapped := atomicValue.swapIfNotEqual(_value); swapped {
+						fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n",
+							key, configVal, oldValue, _value,
+						)
 					}
 				}
 			case *bool:

--- a/config/load.go
+++ b/config/load.go
@@ -75,7 +75,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				}
 				_value = _value * configVal.multiplier.(int)
 				swapHotReloadableConfig(key, "%d", configVal, value, _value)
-			case *int64:
+			case *int64, *Atomic[int64]:
 				var _value int64
 				var isSet bool
 				for _, key := range configVal.keys {
@@ -89,10 +89,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 					_value = configVal.defaultValue.(int64)
 				}
 				_value = _value * configVal.multiplier.(int64)
-				if _value != *value {
-					fmt.Printf("The value of key:%s & variable:%p changed from %d to %d\n", key, configVal, *value, _value)
-					*value = _value
-				}
+				swapHotReloadableConfig(key, "%d", configVal, value, _value)
 			case *string:
 				var _value string
 				var isSet bool

--- a/config/reloadable_benchmark_test.go
+++ b/config/reloadable_benchmark_test.go
@@ -7,13 +7,13 @@ import (
 	"time"
 )
 
-// BenchmarkAtomic/mutex-24						135314967			8.845 ns/op
-// BenchmarkAtomic/rw_mutex-24					132994274			8.715 ns/op
-// BenchmarkAtomic/atomic_value-24				1000000000			0.6007 ns/op
-// BenchmarkAtomic/atomic_custom_mutex-24		77852116			15.19 ns/op
-func BenchmarkAtomic(b *testing.B) {
+// BenchmarkReloadable/mutex-24						135314967			8.845 ns/op
+// BenchmarkReloadable/rw_mutex-24					132994274			8.715 ns/op
+// BenchmarkReloadable/reloadable_value-24				1000000000			0.6007 ns/op
+// BenchmarkReloadable/reloadable_custom_mutex-24		77852116			15.19 ns/op
+func BenchmarkReloadable(b *testing.B) {
 	b.Run("mutex", func(b *testing.B) {
-		var v atomicMutex[int]
+		var v reloadableMutex[int]
 		go func() {
 			for {
 				v.Store(1)
@@ -25,7 +25,7 @@ func BenchmarkAtomic(b *testing.B) {
 		}
 	})
 	b.Run("rw mutex", func(b *testing.B) {
-		var v atomicRWMutex[int]
+		var v reloadableRWMutex[int]
 		go func() {
 			for {
 				v.Store(1)
@@ -36,8 +36,8 @@ func BenchmarkAtomic(b *testing.B) {
 			_ = v.Load()
 		}
 	})
-	b.Run("atomic value", func(b *testing.B) {
-		var v atomicValue[int]
+	b.Run("reloadable value", func(b *testing.B) {
+		var v reloadableValue[int]
 		go func() {
 			for {
 				v.Store(1)
@@ -48,8 +48,8 @@ func BenchmarkAtomic(b *testing.B) {
 			_ = v.Load()
 		}
 	})
-	b.Run("atomic custom mutex", func(b *testing.B) {
-		var v atomicCustomMutex[int]
+	b.Run("reloadable custom mutex", func(b *testing.B) {
+		var v reloadableCustomMutex[int]
 		go func() {
 			for {
 				v.Store(1)
@@ -62,49 +62,49 @@ func BenchmarkAtomic(b *testing.B) {
 	})
 }
 
-type atomicMutex[T comparable] struct {
+type reloadableMutex[T comparable] struct {
 	value T
 	lock  sync.Mutex
 }
 
-func (a *atomicMutex[T]) Load() T {
+func (a *reloadableMutex[T]) Load() T {
 	a.lock.Lock()
 	v := a.value
 	a.lock.Unlock()
 	return v
 }
 
-func (a *atomicMutex[T]) Store(v T) {
+func (a *reloadableMutex[T]) Store(v T) {
 	a.lock.Lock()
 	a.value = v
 	a.lock.Unlock()
 }
 
-type atomicRWMutex[T comparable] struct {
+type reloadableRWMutex[T comparable] struct {
 	value T
 	lock  sync.RWMutex
 }
 
-func (a *atomicRWMutex[T]) Load() T {
+func (a *reloadableRWMutex[T]) Load() T {
 	a.lock.RLock()
 	v := a.value
 	a.lock.RUnlock()
 	return v
 }
 
-func (a *atomicRWMutex[T]) Store(v T) {
+func (a *reloadableRWMutex[T]) Store(v T) {
 	a.lock.Lock()
 	a.value = v
 	a.lock.Unlock()
 }
 
-type atomicValue[T comparable] struct {
-	// Note: it would also be possible to use atomic.Pointer to avoid the panics from
+type reloadableValue[T comparable] struct {
+	// Note: it would also be possible to use reloadable.Pointer to avoid the panics from
 	// atomic.Value but we won't be able to do the "swapIfNotEqual" as a single transaction anyway
 	atomic.Value
 }
 
-func (a *atomicValue[T]) Load() (zero T) {
+func (a *reloadableValue[T]) Load() (zero T) {
 	v := a.Value.Load()
 	if v == nil {
 		return zero
@@ -112,33 +112,33 @@ func (a *atomicValue[T]) Load() (zero T) {
 	return v.(T)
 }
 
-func (a *atomicValue[T]) Store(v T) {
+func (a *reloadableValue[T]) Store(v T) {
 	a.Value.Store(v)
 }
 
-type atomicCustomMutex[T comparable] struct {
+type reloadableCustomMutex[T comparable] struct {
 	value T
 	mutex int32
 }
 
-func (a *atomicCustomMutex[T]) lock() {
+func (a *reloadableCustomMutex[T]) lock() {
 	for atomic.CompareAndSwapInt32(&a.mutex, 0, 1) {
 	}
 }
 
-func (a *atomicCustomMutex[T]) unlock() {
+func (a *reloadableCustomMutex[T]) unlock() {
 	for atomic.CompareAndSwapInt32(&a.mutex, 1, 0) {
 	}
 }
 
-func (a *atomicCustomMutex[T]) Load() T {
+func (a *reloadableCustomMutex[T]) Load() T {
 	a.lock()
 	v := a.value
 	a.unlock()
 	return v
 }
 
-func (a *atomicCustomMutex[T]) Store(v T) {
+func (a *reloadableCustomMutex[T]) Store(v T) {
 	a.lock()
 	a.value = v
 	a.unlock()

--- a/logger/config.go
+++ b/logger/config.go
@@ -2,10 +2,11 @@ package logger
 
 import (
 	"errors"
-	"github.com/rudderlabs/rudder-go-kit/config"
 	"sync"
 
 	"go.uber.org/zap/zapcore"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
 )
 
 // factoryConfig is the configuration for the logger

--- a/logger/config.go
+++ b/logger/config.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"errors"
+	"github.com/rudderlabs/rudder-go-kit/config"
 	"sync"
 
 	"go.uber.org/zap/zapcore"
@@ -9,9 +10,9 @@ import (
 
 // factoryConfig is the configuration for the logger
 type factoryConfig struct {
-	rootLevel        int  // the level for the root logger
-	enableNameInLog  bool // whether to include the logger name in the log message
-	enableStackTrace bool // for fatal logs
+	rootLevel        int                      // the level for the root logger
+	enableNameInLog  bool                     // whether to include the logger name in the log message
+	enableStackTrace *config.Reloadable[bool] // for fatal logs
 
 	levelConfig      *syncMap[string, int] // preconfigured log levels for loggers
 	levelConfigCache *syncMap[string, int] // cache of all calculated log levels for loggers

--- a/logger/factory.go
+++ b/logger/factory.go
@@ -95,7 +95,7 @@ func newConfig(config *config.Config) *factoryConfig {
 	}
 	fc.rootLevel = levelMap[config.GetString("LOG_LEVEL", "INFO")]
 	fc.enableNameInLog = config.GetBool("Logger.enableLoggerNameInLog", true)
-	config.RegisterBoolConfigVariable(false, &fc.enableStackTrace, true, "Logger.enableStackTrace")
+	fc.enableStackTrace = config.RegisterReloadableBoolVar(false, "Logger.enableStackTrace")
 	config.GetBool("Logger.enableLoggerNameInLog", true)
 
 	// colon separated key value pairs

--- a/logger/factory.go
+++ b/logger/factory.go
@@ -95,7 +95,7 @@ func newConfig(config *config.Config) *factoryConfig {
 	}
 	fc.rootLevel = levelMap[config.GetString("LOG_LEVEL", "INFO")]
 	fc.enableNameInLog = config.GetBool("Logger.enableLoggerNameInLog", true)
-	fc.enableStackTrace = config.RegisterReloadableBoolVar(false, "Logger.enableStackTrace")
+	fc.enableStackTrace = config.GetReloadableBoolVar(false, "Logger.enableStackTrace")
 	config.GetBool("Logger.enableLoggerNameInLog", true)
 
 	// colon separated key value pairs

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -181,7 +181,7 @@ func (l *logger) Fatal(args ...interface{}) {
 
 	// If enableStackTrace is true, Zaplogger will take care of writing stacktrace to the file.
 	// Else, we are force writing the stacktrace to the file.
-	if !l.logConfig.enableStackTrace {
+	if !l.logConfig.enableStackTrace.Load() {
 		byteArr := make([]byte, 2048)
 		n := runtime.Stack(byteArr, false)
 		stackTrace := string(byteArr[:n])
@@ -229,7 +229,7 @@ func (l *logger) Fatalf(format string, args ...interface{}) {
 
 	// If enableStackTrace is true, Zaplogger will take care of writing stacktrace to the file.
 	// Else, we are force writing the stacktrace to the file.
-	if !l.logConfig.enableStackTrace {
+	if !l.logConfig.enableStackTrace.Load() {
 		byteArr := make([]byte, 2048)
 		n := runtime.Stack(byteArr, false)
 		stackTrace := string(byteArr[:n])
@@ -277,7 +277,7 @@ func (l *logger) Fatalw(msg string, keysAndValues ...interface{}) {
 
 	// If enableStackTrace is true, Zaplogger will take care of writing stacktrace to the file.
 	// Else, we are force writing the stacktrace to the file.
-	if !l.logConfig.enableStackTrace {
+	if !l.logConfig.enableStackTrace.Load() {
 		byteArr := make([]byte, 2048)
 		n := runtime.Stack(byteArr, false)
 		stackTrace := string(byteArr[:n])


### PR DESCRIPTION
# Description

Now that we're running warehouse tests with the `-race` flags (used in order to prevent races to go to production), we're seeing random failures in some tests (e.g. snowflake integrations) with hot-reloadable configs.

This PR tries to address the issue in a backwards compatible manner and by providing a succint alternative to use the new API without having to burden ourselves with locking and unlocking mutexes each time we have to deal with such variables.

## Context

```
==================
WARNING: DATA RACE
Write at 0x000008f21110 by goroutine 3191:
  github.com/rudderlabs/rudder-go-kit/config.(*Config).RegisterDurationConfigVariable()
      /home/francesco/go/pkg/mod/github.com/rudderlabs/rudder-go-kit@v0.15.7/config/hotreloadable.go:159 +0x66f
  github.com/rudderlabs/rudder-go-kit/config.RegisterDurationConfigVariable()
      /home/francesco/go/pkg/mod/github.com/rudderlabs/rudder-go-kit@v0.15.7/config/hotreloadable.go:133 +0x467
  github.com/rudderlabs/rudder-server/services/pgnotifier.loadPGNotifierConfig()
      /home/francesco/Code/rudderstack/rudder-server/services/pgnotifier/pgnotifier.go:113 +0x3df
  github.com/rudderlabs/rudder-server/services/pgnotifier.Init()
      /home/francesco/Code/rudderstack/rudder-server/services/pgnotifier/pgnotifier.go:55 +0x29
  github.com/rudderlabs/rudder-server/runner.runAllInit()
      /home/francesco/Code/rudderstack/rudder-server/runner/runner.go:331 +0xb3
  github.com/rudderlabs/rudder-server/runner.(*Runner).Run()
      /home/francesco/Code/rudderstack/rudder-server/runner/runner.go:151 +0x100a
  github.com/rudderlabs/rudder-server/warehouse/integrations/snowflake_test.TestIntegration.func1.1()
      /home/francesco/Code/rudderstack/rudder-server/warehouse/integrations/snowflake/snowflake_test.go:189 +0xee

Previous read at 0x000008f21110 by goroutine 258:
  github.com/rudderlabs/rudder-server/services/pgnotifier.(*PGNotifier).Subscribe.func1()
      /home/francesco/Code/rudderstack/rudder-server/services/pgnotifier/pgnotifier.go:616 +0x1e9
  github.com/rudderlabs/rudder-server/rruntime.GoForWarehouse.func1()
      /home/francesco/Code/rudderstack/rudder-server/rruntime/goroutine-factory.go:36 +0x77

Goroutine 3191 (running) created at:
  github.com/rudderlabs/rudder-server/warehouse/integrations/snowflake_test.TestIntegration.func1()
      /home/francesco/Code/rudderstack/rudder-server/warehouse/integrations/snowflake/snowflake_test.go:187 +0x364
  github.com/rudderlabs/rudder-server/warehouse/integrations/snowflake_test.TestIntegration.func2.1()
      /home/francesco/Code/rudderstack/rudder-server/warehouse/integrations/snowflake/snowflake_test.go:332 +0xec
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x47
```

## Linear Ticket

< [Linear Link](https://linear.app/rudderstack/issue/PIPE-205/fix-snowflake-tests-failing-due-to-hot-reloadable-data-race) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
