### PR TITLE
chore: configurable shared memory size for postgres container

### DIFF
--- a/testhelper/docker/resource/postgres.go
+++ b/testhelper/docker/resource/postgres.go
@@ -32,7 +32,7 @@ type PostgresResource struct {
 func SetupPostgres(pool *dockertest.Pool, d cleaner, opts ...func(*postgres.Config)) (*PostgresResource, error) {
 	c := &postgres.Config{
 		Tag:     "15-alpine",
-		ShmSize: 128 * bytesize.MB,
+		ShmSize: 512 * bytesize.MB,
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/testhelper/docker/resource/postgres.go
+++ b/testhelper/docker/resource/postgres.go
@@ -7,7 +7,9 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
+	dc "github.com/ory/dockertest/v3/docker"
 
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
 )
 
@@ -29,7 +31,8 @@ type PostgresResource struct {
 
 func SetupPostgres(pool *dockertest.Pool, d cleaner, opts ...func(*postgres.Config)) (*PostgresResource, error) {
 	c := &postgres.Config{
-		Tag: "15-alpine",
+		Tag:     "15-alpine",
+		ShmSize: 128 * bytesize.MB,
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -49,6 +52,8 @@ func SetupPostgres(pool *dockertest.Pool, d cleaner, opts ...func(*postgres.Conf
 			"POSTGRES_USER=" + postgresDefaultUser,
 		},
 		Cmd: cmd,
+	}, func(hc *dc.HostConfig) {
+		hc.ShmSize = c.ShmSize
 	})
 	if err != nil {
 		return nil, err

--- a/testhelper/docker/resource/postgres/config.go
+++ b/testhelper/docker/resource/postgres/config.go
@@ -14,7 +14,14 @@ func WithOptions(options ...string) Opt {
 	}
 }
 
+func WithShmSize(shmSize int64) Opt {
+	return func(c *Config) {
+		c.ShmSize = shmSize
+	}
+}
+
 type Config struct {
 	Tag     string
 	Options []string
+	ShmSize int64
 }


### PR DESCRIPTION
# Description

Increase the default shared memory size for postgres container to 512MB from 64MB and provide an additional option for overriding it

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
