### PR TITLE
fix: config deadlock by trying to acquire a read lock twice

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,7 +111,7 @@ func GetBool(key string, defaultValue bool) (value bool) {
 func (c *Config) GetBool(key string, defaultValue bool) (value bool) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		return defaultValue
 	}
 	return c.v.GetBool(key)
@@ -126,7 +126,7 @@ func GetInt(key string, defaultValue int) (value int) {
 func (c *Config) GetInt(key string, defaultValue int) (value int) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		return defaultValue
 	}
 	return c.v.GetInt(key)
@@ -141,7 +141,7 @@ func GetStringMap(key string, defaultValue map[string]interface{}) (value map[st
 func (c *Config) GetStringMap(key string, defaultValue map[string]interface{}) (value map[string]interface{}) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		return defaultValue
 	}
 	return c.v.GetStringMap(key)
@@ -156,7 +156,7 @@ func MustGetInt(key string) (value int) {
 func (c *Config) MustGetInt(key string) (value int) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		panic(fmt.Errorf("config key %s not found", key))
 	}
 	return c.v.GetInt(key)
@@ -171,7 +171,7 @@ func GetInt64(key string, defaultValue int64) (value int64) {
 func (c *Config) GetInt64(key string, defaultValue int64) (value int64) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		return defaultValue
 	}
 	return c.v.GetInt64(key)
@@ -186,7 +186,7 @@ func GetFloat64(key string, defaultValue float64) (value float64) {
 func (c *Config) GetFloat64(key string, defaultValue float64) (value float64) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		return defaultValue
 	}
 	return c.v.GetFloat64(key)
@@ -201,7 +201,7 @@ func GetString(key, defaultValue string) (value string) {
 func (c *Config) GetString(key, defaultValue string) (value string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		return defaultValue
 	}
 	return c.v.GetString(key)
@@ -216,7 +216,7 @@ func MustGetString(key string) (value string) {
 func (c *Config) MustGetString(key string) (value string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		panic(fmt.Errorf("config key %s not found", key))
 	}
 	return c.v.GetString(key)
@@ -231,7 +231,7 @@ func GetStringSlice(key string, defaultValue []string) (value []string) {
 func (c *Config) GetStringSlice(key string, defaultValue []string) (value []string) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		return defaultValue
 	}
 	return c.v.GetStringSlice(key)
@@ -246,7 +246,7 @@ func GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.
 func (c *Config) GetDuration(key string, defaultValueInTimescaleUnits int64, timeScale time.Duration) (value time.Duration) {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
-	if !c.IsSet(key) {
+	if !c.isSetInternal(key) {
 		return time.Duration(defaultValueInTimescaleUnits) * timeScale
 	} else {
 		v := c.v.GetString(key)
@@ -273,6 +273,11 @@ func IsSet(key string) bool {
 func (c *Config) IsSet(key string) bool {
 	c.vLock.RLock()
 	defer c.vLock.RUnlock()
+	return c.isSetInternal(key)
+}
+
+// isSetInternal checks if config is set for a key. Caller needs to hold a read lock on vLock.
+func (c *Config) isSetInternal(key string) bool {
 	c.bindEnv(key)
 	return c.v.IsSet(key)
 }

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -91,7 +91,7 @@ func (c *Config) registerIntVar(
 	}
 
 	for _, key := range orderedKeys {
-		if c.IsSet(key) {
+		if c.isSetInternal(key) {
 			store(c.GetInt(key, defaultValue) * valueScale)
 			return
 		}
@@ -180,7 +180,7 @@ func (c *Config) registerBoolVar(defaultValue bool, ptr any, isHotReloadable boo
 
 	for _, key := range orderedKeys {
 		c.bindEnv(key)
-		if c.IsSet(key) {
+		if c.isSetInternal(key) {
 			store(c.GetBool(key, defaultValue))
 			return
 		}
@@ -274,7 +274,7 @@ func (c *Config) registerFloat64Var(
 
 	for _, key := range orderedKeys {
 		c.bindEnv(key)
-		if c.IsSet(key) {
+		if c.isSetInternal(key) {
 			store(c.GetFloat64(key, defaultValue))
 			return
 		}
@@ -368,7 +368,7 @@ func (c *Config) registerInt64Var(
 
 	for _, key := range orderedKeys {
 		c.bindEnv(key)
-		if c.IsSet(key) {
+		if c.isSetInternal(key) {
 			store(c.GetInt64(key, defaultValue) * valueScale)
 			return
 		}
@@ -471,7 +471,7 @@ func (c *Config) registerDurationVar(
 	}
 
 	for _, key := range orderedKeys {
-		if c.IsSet(key) {
+		if c.isSetInternal(key) {
 			store(c.GetDuration(key, defaultValueInTimescaleUnits, timeScale))
 			return
 		}
@@ -563,7 +563,7 @@ func (c *Config) registerStringVar(
 	}
 
 	for _, key := range orderedKeys {
-		if c.IsSet(key) {
+		if c.isSetInternal(key) {
 			store(c.GetString(key, defaultValue))
 			return
 		}
@@ -655,7 +655,7 @@ func (c *Config) registerStringSliceVar(
 	}
 
 	for _, key := range orderedKeys {
-		if c.IsSet(key) {
+		if c.isSetInternal(key) {
 			store(c.GetStringSlice(key, defaultValue))
 			return
 		}
@@ -755,7 +755,7 @@ func (c *Config) registerStringMapVar(
 	}
 
 	for _, key := range orderedKeys {
-		if c.IsSet(key) {
+		if c.isSetInternal(key) {
 			store(c.GetStringMap(key, defaultValue))
 			return
 		}

--- a/config/load.go
+++ b/config/load.go
@@ -64,7 +64,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value int
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.IsSet(key) {
+					if c.isSetInternal(key) {
 						isSet = true
 						_value = c.GetInt(key, configVal.defaultValue.(int))
 						break
@@ -79,7 +79,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value int64
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.IsSet(key) {
+					if c.isSetInternal(key) {
 						isSet = true
 						_value = c.GetInt64(key, configVal.defaultValue.(int64))
 						break
@@ -94,7 +94,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value string
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.IsSet(key) {
+					if c.isSetInternal(key) {
 						isSet = true
 						_value = c.GetString(key, configVal.defaultValue.(string))
 						break
@@ -108,7 +108,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value time.Duration
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.IsSet(key) {
+					if c.isSetInternal(key) {
 						isSet = true
 						_value = c.GetDuration(key, configVal.defaultValue.(int64), configVal.multiplier.(time.Duration))
 						break
@@ -122,7 +122,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value bool
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.IsSet(key) {
+					if c.isSetInternal(key) {
 						isSet = true
 						_value = c.GetBool(key, configVal.defaultValue.(bool))
 						break
@@ -136,7 +136,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value float64
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.IsSet(key) {
+					if c.isSetInternal(key) {
 						isSet = true
 						_value = c.GetFloat64(key, configVal.defaultValue.(float64))
 						break
@@ -151,7 +151,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value []string
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.IsSet(key) {
+					if c.isSetInternal(key) {
 						isSet = true
 						_value = c.GetStringSlice(key, configVal.defaultValue.([]string))
 						break
@@ -167,7 +167,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value map[string]interface{}
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.IsSet(key) {
+					if c.isSetInternal(key) {
 						isSet = true
 						_value = c.GetStringMap(key, configVal.defaultValue.(map[string]interface{}))
 						break


### PR DESCRIPTION
# Description

Internal callers which have already acquired a read lock on `vLock` are now using `isSetInternal` which doesn't acquire any lock.


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
