### PR TITLE
fix: another config deadlock by trying to acquire a read lock twice

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -305,7 +305,7 @@ func getReloadableMapKeys[T configTypes](v T, orderedKeys ...string) (string, st
 func getOrCreatePointer[T configTypes](
 	m map[string]any, dvs map[string]string, // this function MUST receive maps that are already initialized
 	lock *sync.RWMutex, defaultValue T, orderedKeys ...string,
-) *Reloadable[T] {
+) (ptr *Reloadable[T], exists bool) {
 	key, dvKey := getReloadableMapKeys(defaultValue, orderedKeys...)
 
 	lock.Lock()
@@ -324,12 +324,12 @@ func getOrCreatePointer[T configTypes](
 	}()
 
 	if p, ok := m[key]; ok {
-		return p.(*Reloadable[T])
+		return p.(*Reloadable[T]), true
 	}
 
 	p := &Reloadable[T]{}
 	m[key] = p
-	return p
+	return p, false
 }
 
 // bindEnv handles rudder server's unique snake case replacement by registering

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -440,17 +440,21 @@ func TestGetOrCreatePointer(t *testing.T) {
 		dvs = make(map[string]string)
 		rwm sync.RWMutex
 	)
-	p1 := getOrCreatePointer(m, dvs, &rwm, 123, "foo", "bar")
+	p1, exists := getOrCreatePointer(m, dvs, &rwm, 123, "foo", "bar")
 	require.NotNil(t, p1)
+	require.False(t, exists)
 
-	p2 := getOrCreatePointer(m, dvs, &rwm, 123, "foo", "bar")
+	p2, exists := getOrCreatePointer(m, dvs, &rwm, 123, "foo", "bar")
 	require.True(t, p1 == p2)
+	require.True(t, exists)
 
-	p3 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo")
+	p3, exists := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo")
 	require.True(t, p1 != p3)
+	require.False(t, exists)
 
-	p4 := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo", "qux")
+	p4, exists := getOrCreatePointer(m, dvs, &rwm, 123, "bar", "foo", "qux")
 	require.True(t, p1 != p4)
+	require.False(t, exists)
 
 	require.PanicsWithError(t,
 		"Detected misuse of config variable registered with different default values "+
@@ -591,7 +595,6 @@ func Test_Misc(t *testing.T) {
 }
 
 func TestConfigLocking(t *testing.T) {
-
 	const (
 		timeout   = 2 * time.Second
 		configKey = "test"
@@ -667,5 +670,4 @@ func TestConfigLocking(t *testing.T) {
 	})
 
 	require.NoError(t, g.Wait())
-
 }

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -63,12 +63,14 @@ func (c *Config) GetIntVar(defaultValue, valueScale int, orderedKeys ...string) 
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) GetReloadableIntVar(defaultValue, valueScale int, orderedKeys ...string) *Reloadable[int] {
-	ptr := getOrCreatePointer(
+	ptr, exists := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue*valueScale, orderedKeys...,
 	)
-	c.registerIntVar(defaultValue, ptr, true, valueScale, func(v int) {
-		ptr.store(v)
-	}, orderedKeys...)
+	if !exists {
+		c.registerIntVar(defaultValue, ptr, true, valueScale, func(v int) {
+			ptr.store(v)
+		}, orderedKeys...)
+	}
 	return ptr
 }
 
@@ -152,12 +154,14 @@ func (c *Config) GetBoolVar(defaultValue bool, orderedKeys ...string) bool {
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) GetReloadableBoolVar(defaultValue bool, orderedKeys ...string) *Reloadable[bool] {
-	ptr := getOrCreatePointer(
+	ptr, exists := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...,
 	)
-	c.registerBoolVar(defaultValue, ptr, true, func(v bool) {
-		ptr.store(v)
-	}, orderedKeys...)
+	if !exists {
+		c.registerBoolVar(defaultValue, ptr, true, func(v bool) {
+			ptr.store(v)
+		}, orderedKeys...)
+	}
 	return ptr
 }
 
@@ -241,12 +245,14 @@ func (c *Config) GetFloat64Var(defaultValue float64, orderedKeys ...string) floa
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) GetReloadableFloat64Var(defaultValue float64, orderedKeys ...string) *Reloadable[float64] {
-	ptr := getOrCreatePointer(
+	ptr, exists := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...,
 	)
-	c.registerFloat64Var(defaultValue, ptr, true, func(v float64) {
-		ptr.store(v)
-	}, orderedKeys...)
+	if !exists {
+		c.registerFloat64Var(defaultValue, ptr, true, func(v float64) {
+			ptr.store(v)
+		}, orderedKeys...)
+	}
 	return ptr
 }
 
@@ -333,12 +339,14 @@ func (c *Config) GetInt64Var(defaultValue, valueScale int64, orderedKeys ...stri
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) GetReloadableInt64Var(defaultValue, valueScale int64, orderedKeys ...string) *Reloadable[int64] {
-	ptr := getOrCreatePointer(
+	ptr, exists := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue*valueScale, orderedKeys...,
 	)
-	c.registerInt64Var(defaultValue, ptr, true, valueScale, func(v int64) {
-		ptr.store(v)
-	}, orderedKeys...)
+	if !exists {
+		c.registerInt64Var(defaultValue, ptr, true, valueScale, func(v int64) {
+			ptr.store(v)
+		}, orderedKeys...)
+	}
 	return ptr
 }
 
@@ -433,13 +441,15 @@ func (c *Config) GetDurationVar(
 func (c *Config) GetReloadableDurationVar(
 	defaultValueInTimescaleUnits int64, timeScale time.Duration, orderedKeys ...string,
 ) *Reloadable[time.Duration] {
-	ptr := getOrCreatePointer(
+	ptr, exists := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock,
 		time.Duration(defaultValueInTimescaleUnits)*timeScale, orderedKeys...,
 	)
-	c.registerDurationVar(defaultValueInTimescaleUnits, ptr, true, timeScale, func(v time.Duration) {
-		ptr.store(v)
-	}, orderedKeys...)
+	if !exists {
+		c.registerDurationVar(defaultValueInTimescaleUnits, ptr, true, timeScale, func(v time.Duration) {
+			ptr.store(v)
+		}, orderedKeys...)
+	}
 	return ptr
 }
 
@@ -526,12 +536,14 @@ func (c *Config) GetStringVar(defaultValue string, orderedKeys ...string) string
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) GetReloadableStringVar(defaultValue string, orderedKeys ...string) *Reloadable[string] {
-	ptr := getOrCreatePointer(
+	ptr, exists := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...,
 	)
-	c.registerStringVar(defaultValue, ptr, true, func(v string) {
-		ptr.store(v)
-	}, orderedKeys...)
+	if !exists {
+		c.registerStringVar(defaultValue, ptr, true, func(v string) {
+			ptr.store(v)
+		}, orderedKeys...)
+	}
 	return ptr
 }
 
@@ -616,12 +628,14 @@ func (c *Config) GetStringSliceVar(defaultValue []string, orderedKeys ...string)
 // WARNING: keys are being looked up in requested order and the value of the first found key is returned,
 // e.g. asking for the same keys but in a different order can result in a different value to be returned
 func (c *Config) GetReloadableStringSliceVar(defaultValue []string, orderedKeys ...string) *Reloadable[[]string] {
-	ptr := getOrCreatePointer(
+	ptr, exists := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...,
 	)
-	c.registerStringSliceVar(defaultValue, ptr, true, func(v []string) {
-		ptr.store(v)
-	}, orderedKeys...)
+	if !exists {
+		c.registerStringSliceVar(defaultValue, ptr, true, func(v []string) {
+			ptr.store(v)
+		}, orderedKeys...)
+	}
 	return ptr
 }
 
@@ -714,12 +728,14 @@ func (c *Config) GetStringMapVar(
 func (c *Config) GetReloadableStringMapVar(
 	defaultValue map[string]interface{}, orderedKeys ...string,
 ) *Reloadable[map[string]interface{}] {
-	ptr := getOrCreatePointer(
+	ptr, exists := getOrCreatePointer(
 		c.reloadableVars, c.reloadableVarsMisuses, &c.reloadableVarsLock, defaultValue, orderedKeys...,
 	)
-	c.registerStringMapVar(defaultValue, ptr, true, func(v map[string]interface{}) {
-		ptr.store(v)
-	}, orderedKeys...)
+	if !exists {
+		c.registerStringMapVar(defaultValue, ptr, true, func(v map[string]interface{}) {
+			ptr.store(v)
+		}, orderedKeys...)
+	}
 	return ptr
 }
 

--- a/config/hotreloadable.go
+++ b/config/hotreloadable.go
@@ -75,10 +75,6 @@ func (c *Config) GetReloadableIntVar(defaultValue, valueScale int, orderedKeys .
 func (c *Config) registerIntVar(
 	defaultValue int, ptr any, isHotReloadable bool, valueScale int, store func(int), orderedKeys ...string,
 ) {
-	c.vLock.RLock()
-	defer c.vLock.RUnlock()
-	c.hotReloadableConfigLock.Lock()
-	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
 		value:        ptr,
 		multiplier:   valueScale,
@@ -87,11 +83,13 @@ func (c *Config) registerIntVar(
 	}
 
 	if isHotReloadable {
+		c.hotReloadableConfigLock.Lock()
 		c.appendVarToConfigMaps(orderedKeys, &configVar)
+		c.hotReloadableConfigLock.Unlock()
 	}
 
 	for _, key := range orderedKeys {
-		if c.isSetInternal(key) {
+		if c.IsSet(key) {
 			store(c.GetInt(key, defaultValue) * valueScale)
 			return
 		}
@@ -164,10 +162,6 @@ func (c *Config) GetReloadableBoolVar(defaultValue bool, orderedKeys ...string) 
 }
 
 func (c *Config) registerBoolVar(defaultValue bool, ptr any, isHotReloadable bool, store func(bool), orderedKeys ...string) {
-	c.vLock.RLock()
-	defer c.vLock.RUnlock()
-	c.hotReloadableConfigLock.Lock()
-	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
 		value:        ptr,
 		defaultValue: defaultValue,
@@ -175,12 +169,14 @@ func (c *Config) registerBoolVar(defaultValue bool, ptr any, isHotReloadable boo
 	}
 
 	if isHotReloadable {
+		c.hotReloadableConfigLock.Lock()
 		c.appendVarToConfigMaps(orderedKeys, &configVar)
+		c.hotReloadableConfigLock.Unlock()
 	}
 
 	for _, key := range orderedKeys {
 		c.bindEnv(key)
-		if c.isSetInternal(key) {
+		if c.IsSet(key) {
 			store(c.GetBool(key, defaultValue))
 			return
 		}
@@ -257,10 +253,6 @@ func (c *Config) GetReloadableFloat64Var(defaultValue float64, orderedKeys ...st
 func (c *Config) registerFloat64Var(
 	defaultValue float64, ptr any, isHotReloadable bool, store func(float64), orderedKeys ...string,
 ) {
-	c.vLock.RLock()
-	defer c.vLock.RUnlock()
-	c.hotReloadableConfigLock.Lock()
-	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
 		value:        ptr,
 		multiplier:   1.0,
@@ -269,12 +261,14 @@ func (c *Config) registerFloat64Var(
 	}
 
 	if isHotReloadable {
+		c.hotReloadableConfigLock.Lock()
 		c.appendVarToConfigMaps(orderedKeys, &configVar)
+		c.hotReloadableConfigLock.Unlock()
 	}
 
 	for _, key := range orderedKeys {
 		c.bindEnv(key)
-		if c.isSetInternal(key) {
+		if c.IsSet(key) {
 			store(c.GetFloat64(key, defaultValue))
 			return
 		}
@@ -351,10 +345,6 @@ func (c *Config) GetReloadableInt64Var(defaultValue, valueScale int64, orderedKe
 func (c *Config) registerInt64Var(
 	defaultValue int64, ptr any, isHotReloadable bool, valueScale int64, store func(int64), orderedKeys ...string,
 ) {
-	c.vLock.RLock()
-	defer c.vLock.RUnlock()
-	c.hotReloadableConfigLock.Lock()
-	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
 		value:        ptr,
 		multiplier:   valueScale,
@@ -363,12 +353,14 @@ func (c *Config) registerInt64Var(
 	}
 
 	if isHotReloadable {
+		c.hotReloadableConfigLock.Lock()
 		c.appendVarToConfigMaps(orderedKeys, &configVar)
+		c.hotReloadableConfigLock.Unlock()
 	}
 
 	for _, key := range orderedKeys {
 		c.bindEnv(key)
-		if c.isSetInternal(key) {
+		if c.IsSet(key) {
 			store(c.GetInt64(key, defaultValue) * valueScale)
 			return
 		}
@@ -455,10 +447,6 @@ func (c *Config) registerDurationVar(
 	defaultValueInTimescaleUnits int64, ptr any, isHotReloadable bool, timeScale time.Duration,
 	store func(time.Duration), orderedKeys ...string,
 ) {
-	c.vLock.RLock()
-	defer c.vLock.RUnlock()
-	c.hotReloadableConfigLock.Lock()
-	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
 		value:        ptr,
 		multiplier:   timeScale,
@@ -467,11 +455,13 @@ func (c *Config) registerDurationVar(
 	}
 
 	if isHotReloadable {
+		c.hotReloadableConfigLock.Lock()
 		c.appendVarToConfigMaps(orderedKeys, &configVar)
+		c.hotReloadableConfigLock.Unlock()
 	}
 
 	for _, key := range orderedKeys {
-		if c.isSetInternal(key) {
+		if c.IsSet(key) {
 			store(c.GetDuration(key, defaultValueInTimescaleUnits, timeScale))
 			return
 		}
@@ -548,10 +538,6 @@ func (c *Config) GetReloadableStringVar(defaultValue string, orderedKeys ...stri
 func (c *Config) registerStringVar(
 	defaultValue string, ptr any, isHotReloadable bool, store func(string), orderedKeys ...string,
 ) {
-	c.vLock.RLock()
-	defer c.vLock.RUnlock()
-	c.hotReloadableConfigLock.Lock()
-	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
 		value:        ptr,
 		defaultValue: defaultValue,
@@ -559,11 +545,13 @@ func (c *Config) registerStringVar(
 	}
 
 	if isHotReloadable {
+		c.hotReloadableConfigLock.Lock()
 		c.appendVarToConfigMaps(orderedKeys, &configVar)
+		c.hotReloadableConfigLock.Unlock()
 	}
 
 	for _, key := range orderedKeys {
-		if c.isSetInternal(key) {
+		if c.IsSet(key) {
 			store(c.GetString(key, defaultValue))
 			return
 		}
@@ -640,10 +628,6 @@ func (c *Config) GetReloadableStringSliceVar(defaultValue []string, orderedKeys 
 func (c *Config) registerStringSliceVar(
 	defaultValue []string, ptr any, isHotReloadable bool, store func([]string), orderedKeys ...string,
 ) {
-	c.vLock.RLock()
-	defer c.vLock.RUnlock()
-	c.hotReloadableConfigLock.Lock()
-	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
 		value:        ptr,
 		defaultValue: defaultValue,
@@ -651,11 +635,13 @@ func (c *Config) registerStringSliceVar(
 	}
 
 	if isHotReloadable {
+		c.hotReloadableConfigLock.Lock()
 		c.appendVarToConfigMaps(orderedKeys, &configVar)
+		c.hotReloadableConfigLock.Unlock()
 	}
 
 	for _, key := range orderedKeys {
-		if c.isSetInternal(key) {
+		if c.IsSet(key) {
 			store(c.GetStringSlice(key, defaultValue))
 			return
 		}
@@ -740,10 +726,6 @@ func (c *Config) GetReloadableStringMapVar(
 func (c *Config) registerStringMapVar(
 	defaultValue map[string]interface{}, ptr any, isHotReloadable bool, store func(map[string]interface{}), orderedKeys ...string,
 ) {
-	c.vLock.RLock()
-	defer c.vLock.RUnlock()
-	c.hotReloadableConfigLock.Lock()
-	defer c.hotReloadableConfigLock.Unlock()
 	configVar := configValue{
 		value:        ptr,
 		defaultValue: defaultValue,
@@ -751,11 +733,13 @@ func (c *Config) registerStringMapVar(
 	}
 
 	if isHotReloadable {
+		c.hotReloadableConfigLock.Lock()
 		c.appendVarToConfigMaps(orderedKeys, &configVar)
+		c.hotReloadableConfigLock.Unlock()
 	}
 
 	for _, key := range orderedKeys {
-		if c.isSetInternal(key) {
+		if c.IsSet(key) {
 			store(c.GetStringMap(key, defaultValue))
 			return
 		}

--- a/config/load.go
+++ b/config/load.go
@@ -48,8 +48,6 @@ func (c *Config) onConfigChange() {
 			fmt.Println(err)
 		}
 	}()
-	c.vLock.RLock()
-	defer c.vLock.RUnlock()
 	c.hotReloadableConfigLock.RLock()
 	defer c.hotReloadableConfigLock.RUnlock()
 	c.checkAndHotReloadConfig(c.hotReloadableConfig)
@@ -64,7 +62,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value int
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSetInternal(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetInt(key, configVal.defaultValue.(int))
 						break
@@ -79,7 +77,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value int64
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSetInternal(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetInt64(key, configVal.defaultValue.(int64))
 						break
@@ -94,7 +92,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value string
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSetInternal(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetString(key, configVal.defaultValue.(string))
 						break
@@ -108,7 +106,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value time.Duration
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSetInternal(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetDuration(key, configVal.defaultValue.(int64), configVal.multiplier.(time.Duration))
 						break
@@ -122,7 +120,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value bool
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSetInternal(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetBool(key, configVal.defaultValue.(bool))
 						break
@@ -136,7 +134,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value float64
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSetInternal(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetFloat64(key, configVal.defaultValue.(float64))
 						break
@@ -151,7 +149,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value []string
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSetInternal(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetStringSlice(key, configVal.defaultValue.([]string))
 						break
@@ -167,7 +165,7 @@ func (c *Config) checkAndHotReloadConfig(configMap map[string][]*configValue) {
 				var _value map[string]interface{}
 				var isSet bool
 				for _, key := range configVal.keys {
-					if c.isSetInternal(key) {
+					if c.IsSet(key) {
 						isSet = true
 						_value = c.GetStringMap(key, configVal.defaultValue.(map[string]interface{}))
 						break


### PR DESCRIPTION
# Description

`config#registerXxxVar` was acquiring a read lock on `vLock` and after that, another read lock was being acquired on the same lock by `config#GetXxx` before the previous read lock was released, causing a deadlock.

- Simplifying locking by only acquiring locks when necessary (limited scope) and once
- Adding a test to protect against a future regression
- Avoiding to register a reloadable pointer more than once

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
