### PR TITLE
fix: memory gcra limiter inconsistency when rate < cost < burst

### DIFF
--- a/throttling/memory_gcra.go
+++ b/throttling/memory_gcra.go
@@ -54,7 +54,9 @@ func (g *gcra) getLimiter(key string, burst, rate, period int64) (*throttled.GCR
 			return nil, fmt.Errorf("could not create rate limiter: %w", err)
 		}
 		rl.SetMaxCASAttemptsLimit(defaultMaxCASAttemptsLimit)
-		g.store.Put(key, rl, time.Duration(period)*time.Second)
+		// rate limiter should be cached for (burst/rate)*period seconds
+		// e.g. if burst is 100 and rate is 10/sec, then the rate limiter should be cached for 10 seconds
+		g.store.Put(key, rl, time.Duration((burst/rate)*period)*time.Second)
 	}
 
 	return rl, nil

--- a/throttling/memory_gcra_test.go
+++ b/throttling/memory_gcra_test.go
@@ -1,0 +1,35 @@
+package throttling
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryGCRA(t *testing.T) {
+	t.Run("burst and cost greater than rate", func(t *testing.T) {
+		l := &gcra{}
+
+		burst := int64(5)
+		rate := int64(1)
+		period := int64(1)
+
+		limit, err := l.limit(context.Background(), "key", burst+rate, burst, rate, period)
+		require.NoError(t, err)
+		require.True(t, limit, "it should be able to fill the bucket (burst)")
+
+		// next request should be allowed after 4 seconds
+		start := time.Now()
+		var allowed bool
+
+		require.Eventually(t, func() bool {
+			allowed, err = l.limit(context.Background(), "key", burst, burst, rate, period)
+			require.NoError(t, err)
+			return allowed
+		}, 10*time.Second, 1*time.Second, "next request should be eventually allowed")
+
+		require.GreaterOrEqual(t, time.Since(start).Seconds(), 5.0, "next request should be allowed after 5 seconds")
+	})
+}

--- a/throttling/memory_gcra_test.go
+++ b/throttling/memory_gcra_test.go
@@ -20,7 +20,7 @@ func TestMemoryGCRA(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, limit, "it should be able to fill the bucket (burst)")
 
-		// next request should be allowed after 4 seconds
+		// next request should be allowed after 5 seconds
 		start := time.Now()
 		var allowed bool
 


### PR DESCRIPTION
# Description

Extending cache expiration for limiter to account for burst and cost values greater than the rate.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
