### PR TITLE
feat: provide memstat methods to assist on testing (pipe-538)

### DIFF
--- a/stats/memstats/stats.go
+++ b/stats/memstats/stats.go
@@ -256,18 +256,12 @@ func (ms *Store) getAllByName(name string) []Metric {
 	for _, key := range keys {
 		m := ms.byKey[key]
 		switch m.mType {
-		case stats.CountType:
-			metrics = append(metrics, Metric{
+		case stats.CountType, stats.GaugeType:
+			return Metric{
 				Name:  m.name,
 				Tags:  m.tags,
 				Value: m.LastValue(),
-			})
-		case stats.GaugeType:
-			metrics = append(metrics, Metric{
-				Name:  m.name,
-				Tags:  m.tags,
-				Value: m.LastValue(),
-			})
+			}
 		case stats.HistogramType:
 			metrics = append(metrics, Metric{
 				Name:   m.name,

--- a/stats/memstats/stats_test.go
+++ b/stats/memstats/stats_test.go
@@ -14,17 +14,15 @@ import (
 func TestStats(t *testing.T) {
 	now := time.Now()
 
-	store := memstats.New(
-		memstats.WithNow(func() time.Time {
-			return now
-		}),
-	)
-
 	commonTags := stats.Tags{"tag1": "value1"}
 
 	t.Run("test Count", func(t *testing.T) {
 		name := "testCount"
-
+		store := memstats.New(
+			memstats.WithNow(func() time.Time {
+				return now
+			}),
+		)
 		m := store.NewTaggedStat(name, stats.CountType, commonTags)
 
 		m.Increment()
@@ -36,10 +34,27 @@ func TestStats(t *testing.T) {
 
 		require.Equal(t, 3.0, store.Get(name, commonTags).LastValue())
 		require.Equal(t, []float64{1.0, 3.0}, store.Get(name, commonTags).Values())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:  name,
+			Tags:  commonTags,
+			Value: 3.0,
+		}}, store.GetAll())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:  name,
+			Tags:  commonTags,
+			Value: 3.0,
+		}}, store.GetByName(name))
 	})
 
 	t.Run("test Gauge", func(t *testing.T) {
 		name := "testGauge"
+		store := memstats.New(
+			memstats.WithNow(func() time.Time {
+				return now
+			}),
+		)
 		m := store.NewTaggedStat(name, stats.GaugeType, commonTags)
 
 		m.Gauge(1.0)
@@ -51,10 +66,28 @@ func TestStats(t *testing.T) {
 
 		require.Equal(t, 2.0, store.Get(name, commonTags).LastValue())
 		require.Equal(t, []float64{1.0, 2.0}, store.Get(name, commonTags).Values())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:  name,
+			Tags:  commonTags,
+			Value: 2.0,
+		}}, store.GetAll())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:  name,
+			Tags:  commonTags,
+			Value: 2.0,
+		}}, store.GetByName(name))
 	})
 
 	t.Run("test Histogram", func(t *testing.T) {
 		name := "testHistogram"
+		store := memstats.New(
+			memstats.WithNow(func() time.Time {
+				return now
+			}),
+		)
+
 		m := store.NewTaggedStat(name, stats.HistogramType, commonTags)
 
 		m.Observe(1.0)
@@ -66,10 +99,27 @@ func TestStats(t *testing.T) {
 
 		require.Equal(t, 2.0, store.Get(name, commonTags).LastValue())
 		require.Equal(t, []float64{1.0, 2.0}, store.Get(name, commonTags).Values())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:   name,
+			Tags:   commonTags,
+			Values: []float64{1.0, 2.0},
+		}}, store.GetAll())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:   name,
+			Tags:   commonTags,
+			Values: []float64{1.0, 2.0},
+		}}, store.GetByName(name))
 	})
 
 	t.Run("test Timer", func(t *testing.T) {
 		name := "testTimer"
+		store := memstats.New(
+			memstats.WithNow(func() time.Time {
+				return now
+			}),
+		)
 
 		m := store.NewTaggedStat(name, stats.TimerType, commonTags)
 
@@ -100,9 +150,27 @@ func TestStats(t *testing.T) {
 			[]time.Duration{time.Second, time.Minute, time.Second, time.Minute},
 			store.Get(name, commonTags).Durations(),
 		)
+
+		require.Equal(t, []memstats.Metric{{
+			Name:      name,
+			Tags:      commonTags,
+			Durations: []time.Duration{time.Second, time.Minute, time.Second, time.Minute},
+		}}, store.GetAll())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:      name,
+			Tags:      commonTags,
+			Durations: []time.Duration{time.Second, time.Minute, time.Second, time.Minute},
+		}}, store.GetByName(name))
 	})
 
 	t.Run("invalid operations", func(t *testing.T) {
+		store := memstats.New(
+			memstats.WithNow(func() time.Time {
+				return now
+			}),
+		)
+
 		require.PanicsWithValue(t, "operation Count not supported for measurement type:gauge", func() {
 			store.NewTaggedStat("invalid_count", stats.GaugeType, commonTags).Count(1)
 		})
@@ -124,19 +192,81 @@ func TestStats(t *testing.T) {
 		require.PanicsWithValue(t, "operation Observe not supported for measurement type:timer", func() {
 			store.NewTaggedStat("invalid_observe", stats.TimerType, commonTags).Observe(1)
 		})
+
+		require.PanicsWithValue(t, "name cannot be empty", func() {
+			store.GetByName("")
+		})
 	})
 
 	t.Run("no op", func(t *testing.T) {
+		store := memstats.New(
+			memstats.WithNow(func() time.Time {
+				return now
+			}),
+		)
+
 		require.NoError(t, store.Start(context.Background(), stats.DefaultGoRoutineFactory))
 		store.Stop()
+
+		require.Equal(t, []memstats.Metric{}, store.GetAll())
 	})
 
 	t.Run("no tags", func(t *testing.T) {
 		name := "no_tags"
+		store := memstats.New(
+			memstats.WithNow(func() time.Time {
+				return now
+			}),
+		)
+
 		m := store.NewStat(name, stats.CountType)
 
 		m.Increment()
 
 		require.Equal(t, 1.0, store.Get(name, nil).LastValue())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:  name,
+			Value: 1.0,
+		}}, store.GetAll())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:  name,
+			Value: 1.0,
+		}}, store.GetByName(name))
+	})
+
+	t.Run("get by name", func(t *testing.T) {
+		name1 := "name_1"
+		name2 := "name_2"
+
+		store := memstats.New(
+			memstats.WithNow(func() time.Time {
+				return now
+			}),
+		)
+
+		m1 := store.NewStat(name1, stats.CountType)
+		m1.Increment()
+		m2 := store.NewStat(name2, stats.TimerType)
+		m2.SendTiming(time.Second)
+
+		require.Equal(t, []memstats.Metric{{
+			Name:  name1,
+			Value: 1.0,
+		}}, store.GetByName(name1))
+
+		require.Equal(t, []memstats.Metric{{
+			Name:      name2,
+			Durations: []time.Duration{time.Second},
+		}}, store.GetByName(name2))
+
+		require.Equal(t, []memstats.Metric{{
+			Name:  name1,
+			Value: 1.0,
+		}, {
+			Name:      name2,
+			Durations: []time.Duration{time.Second},
+		}}, store.GetAll())
 	})
 }


### PR DESCRIPTION
# Description

## Motivation 
The existing method for verifying stats `.Get` during tests was limiting and cumbersome.

You could only retrieve a specific combination of name and tags. This way:
* You could not test if other metrics were created during the execution. https://github.com/rudderlabs/rudder-server/pull/3974#discussion_r1378951251
* It is difficult to find the problem if the particular combination of name+tags is missing.

For these reasons, I wanted a way to retrieve a collection of metrics registered to the store.


## Solution
* Introduce `.GetAll` which returns a Metrics array, containing all possible name+stats combinations captured using the storage.
* Introduce `.GetByName` which returns the subset that belongs to a measurement name.


`Metric` type is a bit special, it has
*  `Value` just float used for metrics/gauges
* `Values` float array for histograms  
*  `Durations` for timers

The motivation here was to use the most convenient representation for the stat type used. I tried a few approaches:
* using a method per stat type
* using generic interface to describe each Metric

However, both approaches had extra overhead when writing tests. So, I decided to go with the simpler approach from the perspective of validation.

You can seem them being used [here](https://github.com/rudderlabs/rudder-server/pull/4104/files#diff-9aacf3c6a21b6fc5f095d8a16c7a82792a362da1c8cd3cd6e988515f30ab40daR91)


## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-538/improve-memstats-testing

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
