### PR TITLE
chore: golangci-lint no docker

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,4 +50,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.55.2

--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ install-tools:
 	go install mvdan.cc/gofumpt@latest
 	go install gotest.tools/gotestsum@v1.8.2
 	go install golang.org/x/tools/cmd/goimports@latest
+	bash ./internal/scripts/install-golangci-lint.sh v1.55.2
 
 .PHONY: lint
 lint: fmt ## Run linters on all go files
-	docker run --rm -v $(shell pwd):/app:ro -w /app golangci/golangci-lint:v1.54.2 bash -e -c \
-		'golangci-lint run -v --timeout 5m'
+	golangci-lint run -v --timeout 5m
 
 .PHONY: fmt
 fmt: install-tools ## Formats all go files

--- a/internal/scripts/install-golangci-lint.sh
+++ b/internal/scripts/install-golangci-lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+VERSION=$1
+[ -z "${VERSION}" ] && VERSION="v1.55.2"
+GOPATH=$(go env GOPATH)
+[ -f "${GOPATH}/bin/golangci-lint-${VERSION}" ] && echo "golangci-lint ${VERSION} is already installed" || \
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/${VERSION}/install.sh | sh -s -- -b ${GOPATH}/bin ${VERSION} && \
+cp ${GOPATH}/bin/golangci-lint ${GOPATH}/bin/golangci-lint-${VERSION}


### PR DESCRIPTION
# Description

Standardizing approach with rudder-server.

## Linear Ticket

< [Linear_Link](https://linear.app/rudderstack/issue/PIPE-565/use-same-golangci-lint-approach-in-go-kit-no-docker) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
