### PR TITLE
chore: adding sdk to otel group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       opentelemetry:
         patterns:
           - "go.opentelemetry.io/otel*"
+          - "go.opentelemetry.io/otel/sdk"
           - "go.opentelemetry.io/collector*"
           - "github.com/open-telemetry/o*-collector-contrib/*"
           - "go.opentelemetry.io/contrib/instrumentation/*"


### PR DESCRIPTION
# Description

Updating Dependabot configuration as per Jaeger example to group OTEL dependencies.

## Linear Ticket

< [Linear_Link](https://linear.app/rudderstack/issue/PIPE-733/dependabot-otel) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
