### PR TITLE
feat: add async.SingleSender and a new docker resource for mysql

### DIFF
--- a/async/single_sender.go
+++ b/async/single_sender.go
@@ -1,0 +1,52 @@
+package async
+
+import (
+	"context"
+)
+
+// SingleSender is a helper for sending and receiving values to and from a channel between 2 separate goroutines, a sending and a receiving goroutine, while at the same time supporting the following scenarios:
+//  1. The sending goroutine in case the parent context is canceled should be able to notify the receiver goroutine about the error through the channel.
+//  2. The receiving goroutine should be able to stop listening from the channel (a.k.a. leave) at any point.
+//  3. The sending goroutine shouldn't be blocked trying to send to the channel when the receiver has left it.
+//  4. Receiver's departure should act as a context cancellation signal to the sending goroutine, i.e. it should stop working.
+type SingleSender[T any] struct {
+	ctx           context.Context
+	ctxCancel     context.CancelFunc
+	sendCtx       context.Context
+	sendCtxCancel context.CancelFunc
+	ch            chan T
+	closed        bool
+}
+
+// Begin creates a new channel and returns it along with a context for the sending goroutine to use and a function for the receiving goroutine to be able to leave the "conversation" if needed.
+func (s *SingleSender[T]) Begin(parentCtx context.Context) (ctx context.Context, ch <-chan T, leave func()) {
+	s.ctx, s.ctxCancel = context.WithCancel(parentCtx)
+	s.ch = make(chan T)
+	s.sendCtx, s.sendCtxCancel = context.WithCancel(context.Background())
+	return s.ctx, s.ch, s.sendCtxCancel
+}
+
+// Send tries to send a value to the channel. If the channel is closed, or the receiving goroutine has left it does nothing.
+func (s *SingleSender[T]) Send(value T) {
+	closed := s.closed
+	if closed { // don't send to a closed channel
+		return
+	}
+	select {
+	case <-s.sendCtx.Done():
+		s.ctxCancel()
+		return
+	case s.ch <- value:
+	}
+}
+
+// Close the channel and cancel all related contexts.
+func (s *SingleSender[T]) Close() {
+	if s.closed {
+		return
+	}
+	s.closed = true
+	s.ctxCancel()
+	s.sendCtxCancel()
+	close(s.ch)
+}

--- a/async/single_sender_test.go
+++ b/async/single_sender_test.go
@@ -1,0 +1,222 @@
+package async_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/rudderlabs/rudder-go-kit/async"
+)
+
+func TestSingleSender(t *testing.T) {
+	type valueOrError struct {
+		value int
+		err   error
+	}
+
+	send := func(ctx context.Context, s *async.SingleSender[valueOrError], times int) (sendCalls int) {
+		defer s.Close()
+		for i := 0; i < times; i++ {
+			if ctx.Err() != nil {
+				s.Send(valueOrError{err: ctx.Err()})
+				return
+			}
+			s.Send(valueOrError{value: i})
+			sendCalls++
+		}
+		return sendCalls
+	}
+
+	receive := func(ch <-chan valueOrError, delay time.Duration) ([]int, []error) {
+		var receivedValues []int
+		var receivedErrors []error
+		for v := range ch {
+			time.Sleep(delay)
+			if v.err != nil {
+				receivedErrors = append(receivedErrors, v.err)
+			} else {
+				receivedValues = append(receivedValues, v.value)
+			}
+		}
+		return receivedValues, receivedErrors
+	}
+
+	t.Run("receive all values from sender", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+		s := &async.SingleSender[valueOrError]{}
+		ctx, ch, _ := s.Begin(context.Background())
+		defer s.Close()
+
+		g := &errgroup.Group{}
+
+		var sendCalls int
+		g.Go(func() error {
+			sendCalls = send(ctx, s, 10)
+			return nil
+		})
+
+		var receivedValues []int
+		var receivedErrors []error
+		g.Go(func() error {
+			receivedValues, receivedErrors = receive(ch, 0)
+			return nil
+		})
+
+		_ = g.Wait()
+
+		require.Equal(t, 10, sendCalls)
+		require.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, receivedValues)
+		require.Empty(t, receivedErrors)
+	})
+
+	t.Run("parent context is canceled", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+		parentCtx, parentCtxCancel := context.WithCancel(context.Background())
+		parentCtxCancel()
+		s := &async.SingleSender[valueOrError]{}
+		ctx, ch, _ := s.Begin(parentCtx)
+		defer s.Close()
+
+		g := &errgroup.Group{}
+
+		var sendCalls int
+		g.Go(func() error {
+			sendCalls = send(ctx, s, 10)
+			return nil
+		})
+
+		var receivedValues []int
+		var receivedErrors []error
+
+		g.Go(func() error {
+			receivedValues, receivedErrors = receive(ch, 0)
+			return nil
+		})
+		_ = g.Wait()
+
+		require.Zero(t, sendCalls)
+		require.Nil(t, receivedValues, "no values should be received")
+		require.Equal(t, []error{context.Canceled}, receivedErrors)
+	})
+
+	t.Run("parent context is canceled after interaction has started", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+		parentCtx, parentCtxCancel := context.WithCancel(context.Background())
+
+		s := &async.SingleSender[valueOrError]{}
+		ctx, ch, _ := s.Begin(parentCtx)
+		defer s.Close()
+
+		g := &errgroup.Group{}
+
+		var sendCalls int
+		g.Go(func() error {
+			sendCalls = send(ctx, s, 1000)
+			return nil
+		})
+
+		var receivedValues []int
+		var receivedErrors []error
+
+		g.Go(func() error {
+			receivedValues, receivedErrors = receive(ch, 10*time.Millisecond)
+			return nil
+		})
+		time.Sleep(time.Millisecond * 100)
+		parentCtxCancel()
+		_ = g.Wait()
+
+		require.GreaterOrEqual(t, sendCalls, 1, "sender should have called send at least for 1 value")
+		require.GreaterOrEqual(t, len(receivedValues), 1, "receiver should have called received at least for 1 value")
+		require.Equal(t, []error{context.Canceled}, receivedErrors)
+	})
+
+	t.Run("try to send another value after sender is closed", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+		s := async.SingleSender[valueOrError]{}
+		_, ch, _ := s.Begin(context.Background())
+		defer s.Close()
+
+		g := &errgroup.Group{}
+
+		g.Go(func() error {
+			for i := 0; i < 10; i++ {
+				s.Send(valueOrError{value: i})
+			}
+			s.Close()
+			s.Send(valueOrError{value: 10})
+			return nil
+		})
+
+		var receivedValues []int
+		var receivedErrors []error
+
+		g.Go(func() error {
+			receivedValues, receivedErrors = receive(ch, 0)
+			return nil
+		})
+		_ = g.Wait()
+
+		require.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, receivedValues)
+		require.Empty(t, receivedErrors)
+	})
+
+	t.Run("receiver leaves before sender sends all values", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+		s := async.SingleSender[valueOrError]{}
+		ctx, ch, leave := s.Begin(context.Background())
+		defer s.Close()
+
+		g := &errgroup.Group{}
+
+		var sendCalls int
+		g.Go(func() error {
+			sendCalls = send(ctx, &s, 10)
+			return nil
+		})
+
+		var receivedValues []int
+		var receivedErrors []error
+
+		g.Go(func() error {
+			for v := range ch {
+				if v.err != nil {
+					receivedErrors = append(receivedErrors, v.err)
+				} else {
+					receivedValues = append(receivedValues, v.value)
+				}
+				// leave after receiving 1 value
+				leave()
+				// make sure sender has time to try and send another value and figure out that context is canceled
+				time.Sleep(100 * time.Millisecond)
+			}
+			return nil
+		})
+		_ = g.Wait()
+
+		require.GreaterOrEqual(t, len(receivedValues), 1, "receiver should have received at least 1 value")
+		require.LessOrEqual(t, len(receivedValues), 2, "receiver should have received at most 2 values")
+		require.GreaterOrEqual(t, sendCalls, 1, "sender should have called send at least for 1 value")
+		require.LessOrEqual(t, sendCalls, 2, "sender should have called send at most for 2 values, i.e. it should stop sending after receiver leaves")
+	})
+
+	t.Run("sender closes then sends again", func(t *testing.T) {
+		s := async.SingleSender[valueOrError]{}
+		_, ch, _ := s.Begin(context.Background())
+		go func() {
+			s.Close()
+			s.Send(valueOrError{value: 1})
+		}()
+
+		var values []int
+		for range ch {
+			values = append(values, 1)
+		}
+
+		require.Empty(t, values)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.23.1
 	go.opentelemetry.io/otel/sdk/metric v1.23.1
 	go.opentelemetry.io/otel/trace v1.23.1
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.19.0
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a

--- a/testhelper/docker/resource/mysql/config.go
+++ b/testhelper/docker/resource/mysql/config.go
@@ -1,0 +1,20 @@
+package mysql
+
+type Opt func(*Config)
+
+func WithTag(tag string) Opt {
+	return func(c *Config) {
+		c.Tag = tag
+	}
+}
+
+func WithShmSize(shmSize int64) Opt {
+	return func(c *Config) {
+		c.ShmSize = shmSize
+	}
+}
+
+type Config struct {
+	Tag     string
+	ShmSize int64
+}

--- a/testhelper/docker/resource/mysql/mysql_test.go
+++ b/testhelper/docker/resource/mysql/mysql_test.go
@@ -1,0 +1,36 @@
+package mysql_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	// _ "github.com/go-sql-driver/mysql" // mysql driver uses MPL-2.0 license
+	"github.com/rudderlabs/rudder-go-kit/bytesize"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/mysql"
+)
+
+func TestMySQL(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err, "it should be able to create a docker pool")
+	mysqlResource, err := mysql.Setup(pool, t, mysql.WithShmSize(10*bytesize.MB), mysql.WithTag("8.2.0"))
+	require.NoError(t, err, "it should be able to create a mysql resource")
+
+	if true {
+		t.Skip("Skipping test due to mysql driver license restrictions")
+	}
+	db, err := sql.Open("mysql", mysqlResource.DBDsn)
+	require.NoError(t, err, "it should be able to open a mysql connection")
+	require.NoError(t, db.Ping(), "it should be able to ping mysql")
+
+	_, err = db.Exec("CREATE SCHEMA `TesT`")
+	require.NoError(t, err, "it should be able to create a schema")
+	_, err = db.Exec("CREATE TABLE `TesT`.`TeSt` (id INT, name VARCHAR(255))")
+	require.NoError(t, err, "it should be able to create a table")
+	row := db.QueryRow("SELECT count(`TesT`.`TeSt`.id) FROM `TesT`.`TeSt`")
+	var count int
+	require.NoError(t, row.Scan(&count), "it should be able to scan a row")
+	require.Equal(t, 0, count, "it should be able to scan a row")
+}

--- a/testhelper/docker/resource/postgres/config.go
+++ b/testhelper/docker/resource/postgres/config.go
@@ -32,10 +32,17 @@ func WithOOMKillDisable(disable bool) Opt {
 	}
 }
 
+func WithPrintLogsOnError(printLogsOnError bool) Opt {
+	return func(c *Config) {
+		c.PrintLogsOnError = printLogsOnError
+	}
+}
+
 type Config struct {
-	Tag            string
-	Options        []string
-	ShmSize        int64
-	Memory         int64
-	OOMKillDisable bool
+	Tag              string
+	Options          []string
+	ShmSize          int64
+	Memory           int64
+	OOMKillDisable   bool
+	PrintLogsOnError bool
 }

--- a/testhelper/docker/resource/postgres/postgres.go
+++ b/testhelper/docker/resource/postgres/postgres.go
@@ -67,7 +67,7 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...func(*Config)) (*R
 	}
 
 	d.Cleanup(func() {
-		if d.Failed() {
+		if d.Failed() && c.PrintLogsOnError {
 			if c, found := pool.ContainerByName(postgresContainer.Container.Name); found {
 				d.Log(fmt.Sprintf("%q postgres container state: %+v", c.Container.Name, c.Container.State))
 				b := bytes.NewBufferString("")

--- a/testhelper/docker/resource/postgres/postgres_test.go
+++ b/testhelper/docker/resource/postgres/postgres_test.go
@@ -34,7 +34,7 @@ func TestPostgres(t *testing.T) {
 
 	t.Run("with test failure", func(t *testing.T) {
 		cl := &testCleaner{T: t, failed: true}
-		r, err := postgres.Setup(pool, cl)
+		r, err := postgres.Setup(pool, cl, postgres.WithPrintLogsOnError(true))
 		require.NoError(t, err)
 		err = pool.Client.StopContainer(r.ContainerID, 10)
 		require.NoError(t, err)


### PR DESCRIPTION
# Description

`async.SingleSender` is a helper for sending and receiving values to and from a channel between 2 separate goroutines, a sending and a receiving goroutine, while at the same time supporting the following scenarios::
  1. The sending goroutine in case the parent context is canceled should be able to notify the receiver goroutine about the error through the channel.
  2. The receiving goroutine should be able to stop listening from the channel (a.k.a. leave) at any point.
  3. The sending goroutine shouldn't be blocked trying to send to the channel when the receiver has left it.
  4. Receiver's departure should act as a context cancellation signal to the sending goroutine, i.e. it should stop working.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
