### PR TITLE
feat: add mock config BE support for transformer

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: codecov/codecov-action@v3
   test-package:
     name: Test package
-    runs-on: 'ubuntu-20.04'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit:
     name: unit
-    runs-on: 'ubuntu-20.04'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/json-iterator/go v1.1.12
 	github.com/lib/pq v1.10.9
@@ -82,7 +83,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
 	github.com/throttled/throttled/v2 v2.12.0
+	github.com/tidwall/gjson v1.17.1
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
 	go.opentelemetry.io/otel v1.23.1
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.23.1
@@ -121,6 +122,8 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,12 @@ github.com/testcontainers/testcontainers-go v0.14.0 h1:h0D5GaYG9mhOWr2qHdEKDXpkc
 github.com/testcontainers/testcontainers-go v0.14.0/go.mod h1:hSRGJ1G8Q5Bw2gXgPulJOLlEBaYJHeBSOkQM5JLG+JQ=
 github.com/throttled/throttled/v2 v2.12.0 h1:IezKE1uHlYC/0Al05oZV6Ar+uN/znw3cy9J8banxhEY=
 github.com/throttled/throttled/v2 v2.12.0/go.mod h1:+EAvrG2hZAQTx8oMpBu8fq6Xmm+d1P2luKK7fIY1Esc=
+github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
+github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/testhelper/docker/docker.go
+++ b/testhelper/docker/docker.go
@@ -1,8 +1,8 @@
 package docker
 
 import (
+	"regexp"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/ory/dockertest/v3/docker"
@@ -24,7 +24,5 @@ func GetHostPort(t testing.TB, port string, container *docker.Container) int {
 
 // ToInternalDockerHost replaces localhost and 127.0.0.1 with host.docker.internal
 func ToInternalDockerHost(url string) string {
-	url = strings.ReplaceAll(url, "localhost", "host.docker.internal")
-	url = strings.ReplaceAll(url, "127.0.0.1", "host.docker.internal")
-	return url
+	return regexp.MustCompile(`(localhost|127\.0\.0\.1)`).ReplaceAllString(url, "host.docker.internal")
 }

--- a/testhelper/docker/docker.go
+++ b/testhelper/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ory/dockertest/v3/docker"
@@ -19,4 +20,11 @@ func GetHostPort(t testing.TB, port string, container *docker.Container) int {
 		}
 	}
 	return 0
+}
+
+// ToInternalDockerHost replaces localhost and 127.0.0.1 with host.docker.internal
+func ToInternalDockerHost(url string) string {
+	url = strings.ReplaceAll(url, "localhost", "host.docker.internal")
+	url = strings.ReplaceAll(url, "127.0.0.1", "host.docker.internal")
+	return url
 }

--- a/testhelper/docker/resource/transformer/transformer_backend_config.go
+++ b/testhelper/docker/resource/transformer/transformer_backend_config.go
@@ -1,0 +1,53 @@
+package transformer
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	getByVersionIdEndPoint = "/transformation/getByVersionId"
+	versionIDKey           = "versionId"
+)
+
+type mockHttpServer struct {
+	Transformations map[string]string
+}
+
+func (m *mockHttpServer) handleGetByVersionId(w http.ResponseWriter, r *http.Request) {
+	transformationVersionId := r.URL.Query().Get(versionIDKey)
+	transformationCode, ok := m.Transformations[transformationVersionId]
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	transformationCode = sanitiseTransformationCode(transformationCode)
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte(fmt.Sprintf(`{
+		"id": "%s",
+		"createdAt": "2023-03-27T11:40:00.894Z",
+		"updatedAt": "2023-03-27T11:40:00.894Z",
+		"versionId": "%s",
+		"name": "Add Transformed field",
+		"description": "",
+		"code": "%s",
+		"secretsVersion": null,
+		"codeVersion": "1",
+		"language": "javascript",
+		"imports": [],
+		"secrets": {}
+	}`, uuid.NewString(), transformationVersionId, transformationCode)))
+	if err != nil {
+		return
+	}
+	w.WriteHeader(http.StatusInternalServerError)
+}
+
+func sanitiseTransformationCode(transformationCode string) string {
+	sanitisedTransformationCode := strings.ReplaceAll(transformationCode, "\t", " ")
+	sanitisedTransformationCode = strings.ReplaceAll(sanitisedTransformationCode, "\n", "\\n")
+	return sanitisedTransformationCode
+}

--- a/testhelper/docker/resource/transformer/transformer_test.go
+++ b/testhelper/docker/resource/transformer/transformer_test.go
@@ -1,6 +1,8 @@
 package transformer_test
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -15,7 +17,7 @@ func TestSetup(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 
-	t.Run("check get endpoints", func(t *testing.T) {
+	t.Run("test get endpoints", func(t *testing.T) {
 		tests := []struct {
 			name    string
 			tag     string
@@ -56,5 +58,50 @@ func TestSetup(t *testing.T) {
 				require.Equal(t, resp.StatusCode, http.StatusOK)
 			})
 		}
+	})
+
+	t.Run("test custom transformation", func(t *testing.T) {
+		transformations := map[string]string{
+			"2Nazu8t4ujUC0Dzc4pBFbjmOijx": `export function transformEvent(event, metadata) {
+													event.transformed=true
+													return event;
+												}`,
+		}
+		transformerContainer, err := transformer.Setup(pool, t, transformer.WithTransformations(transformations, t))
+		require.NoError(t, err)
+
+		transformerURL, err := url.JoinPath(transformerContainer.TransformerURL, "customTransform")
+		require.NoError(t, err)
+
+		rawReq := []byte(`[{"message":{
+				"userId": "identified_user_id",
+				"anonymousId":"anonymousId_1",
+				"messageId":"messageId_1",
+				"type": "track",
+				"event": "Product Reviewed",
+				"properties": {
+				  "review_id": "12345",
+				  "product_id" : "123",
+				  "rating" : 3.5,
+				  "review_body" : "Average product, expected much more."
+				}
+			},"metadata":{"sourceId":"xxxyyyzzEaEurW247ad9WYZLUyk","workspaceId":"fyJvxaglFrCFxsBcLiSPBCmgpWK",
+			"messageId":"messageId_1"},"destination":{"Transformations":[{"VersionID":"2Nazu8t4ujUC0Dzc4pBFbjmOijx","ID":""}]}}]`)
+		req, reqErr := http.NewRequest(http.MethodPost, transformerURL, bytes.NewBuffer(rawReq))
+		if reqErr != nil {
+			return
+		}
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		req.Header.Set("X-Feature-Gzip-Support", "?1")
+		// Header to let transformer know that the client understands event filter code
+		req.Header.Set("X-Feature-Filter-Code", "?1")
+
+		resp, err := http.DefaultClient.Do(req)
+		defer func() { _ = resp.Body.Close() }()
+		require.NoError(t, err)
+		// require.Equal(t, http.StatusOK, resp.StatusCode)
+		respData, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(respData), `"transformed":true`)
 	})
 }

--- a/testhelper/docker/resource/transformer/transformer_test.go
+++ b/testhelper/docker/resource/transformer/transformer_test.go
@@ -7,6 +7,10 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/tidwall/gjson"
+
+	"github.com/rudderlabs/rudder-go-kit/httputil"
+
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
@@ -67,7 +71,7 @@ func TestSetup(t *testing.T) {
 													return event;
 												}`,
 		}
-		transformerContainer, err := transformer.Setup(pool, t, transformer.WithTransformations(transformations, t))
+		transformerContainer, err := transformer.Setup(pool, t, transformer.WithUserTransformations(transformations, t))
 		require.NoError(t, err)
 
 		transformerURL, err := url.JoinPath(transformerContainer.TransformerURL, "customTransform")
@@ -88,20 +92,18 @@ func TestSetup(t *testing.T) {
 			},"metadata":{"sourceId":"xxxyyyzzEaEurW247ad9WYZLUyk","workspaceId":"fyJvxaglFrCFxsBcLiSPBCmgpWK",
 			"messageId":"messageId_1"},"destination":{"Transformations":[{"VersionID":"2Nazu8t4ujUC0Dzc4pBFbjmOijx","ID":""}]}}]`)
 		req, reqErr := http.NewRequest(http.MethodPost, transformerURL, bytes.NewBuffer(rawReq))
-		if reqErr != nil {
-			return
-		}
+		require.NoError(t, reqErr)
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 		req.Header.Set("X-Feature-Gzip-Support", "?1")
 		// Header to let transformer know that the client understands event filter code
 		req.Header.Set("X-Feature-Filter-Code", "?1")
 
 		resp, err := http.DefaultClient.Do(req)
-		defer func() { _ = resp.Body.Close() }()
+		defer func() { httputil.CloseResponse(resp) }()
 		require.NoError(t, err)
-		// require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 		respData, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.Contains(t, string(respData), `"transformed":true`)
+		require.True(t, gjson.Get(string(respData), "0.output.transformed").Bool())
 	})
 }

--- a/testhelper/httptest/httptest.go
+++ b/testhelper/httptest/httptest.go
@@ -1,0 +1,47 @@
+package httptest
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	nethttptest "net/http/httptest"
+)
+
+// NewServer starts a new httptest server that listens on all interfaces, contrary to the standard net/httptest.Server that listens only on localhost.
+// This is useful when you want to access the test http server from within a docker container.
+func NewServer(handler http.Handler) *Server {
+	ts := newUnStartedServer(handler)
+	ts.Start()
+	return ts
+}
+
+// Simple net/httptest.Server wrapper
+type Server struct {
+	*nethttptest.Server
+}
+
+func (s *Server) Start() {
+	s.Server.Start()
+	_, port, err := net.SplitHostPort(s.Listener.Addr().String())
+	if err != nil {
+		panic(fmt.Sprintf("httptest: failed to parse listener address: %v", err))
+	}
+	s.URL = fmt.Sprintf("http://%s:%s", "localhost", port)
+}
+
+func newUnStartedServer(handler http.Handler) *Server {
+	return &Server{&nethttptest.Server{
+		Listener: newListener(),
+		Config:   &http.Server{Handler: handler},
+	}}
+}
+
+func newListener() net.Listener {
+	l, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		if l, err = net.Listen("tcp6", "[::]:0"); err != nil {
+			panic(fmt.Sprintf("httptest: failed to listen on a port: %v", err))
+		}
+	}
+	return l
+}

--- a/testhelper/httptest/httptest_test.go
+++ b/testhelper/httptest/httptest_test.go
@@ -1,0 +1,45 @@
+package httptest_test
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/httputil"
+	kithttptest "github.com/rudderlabs/rudder-go-kit/testhelper/httptest"
+)
+
+func TestServer(t *testing.T) {
+	httpServer := kithttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Hello, world!"))
+	}))
+	defer httpServer.Close()
+
+	httpServerParsedURL, err := url.Parse(httpServer.URL)
+	require.NoError(t, err)
+
+	_, httpServerPort, err := net.SplitHostPort(httpServerParsedURL.Host)
+	require.NoError(t, err)
+
+	var (
+		body       []byte
+		statusCode int
+	)
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://0.0.0.0:" + httpServerPort)
+		defer func() { httputil.CloseResponse(resp) }()
+		if err == nil {
+			statusCode = resp.StatusCode
+			body, err = io.ReadAll(resp.Body)
+		}
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond, "failed to connect to proxy")
+
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, "Hello, world!", string(body))
+}


### PR DESCRIPTION
# Description
Add support to mock config backend with transformer resource initialisation. This will allow tests to run independent of actual config backend. Test will not fail even if control plane is down.

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-804/mock-config-be-for-transformer-resource-in-go-kit

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
