### PR TITLE
chore: close postgres db on cleanup

### DIFF
--- a/testhelper/docker/resource/redis/redis.go
+++ b/testhelper/docker/resource/redis/redis.go
@@ -79,6 +79,7 @@ func Setup(ctx context.Context, pool *dockertest.Pool, d resource.Cleaner, opts 
 		redisClient := redis.NewClient(&redis.Options{
 			Addr: addr,
 		})
+		defer func() { _ = redisClient.Close() }()
 		_, err := redisClient.Ping(ctx).Result()
 		return err
 	})


### PR DESCRIPTION
# Description

Closing postgres sql.DB on cleanup to avoid resource leaks

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
