### PR TITLE
chore: export config BE handler for transformer, and unstarted http test server

### DIFF
--- a/testhelper/docker/resource/transformer/transformer.go
+++ b/testhelper/docker/resource/transformer/transformer.go
@@ -66,6 +66,14 @@ func WithUserTransformations(transformations map[string]string, cleaner resource
 	}
 }
 
+// WithConnectionToHostEnabled lets transformer container connect with the host machine
+// i.e. transformer container will be able to access localhost of the host machine
+func WithConnectionToHostEnabled() func(*config) {
+	return func(conf *config) {
+		conf.extraHosts = append(conf.extraHosts, "host.docker.internal:host-gateway")
+	}
+}
+
 // WithConfigBackendURL lets transformer use custom backend config server for transformations
 // WithConfigBackendURL should not be used with WithUserTransformations option
 func WithConfigBackendURL(url string) func(*config) {

--- a/testhelper/docker/resource/transformer/transformer.go
+++ b/testhelper/docker/resource/transformer/transformer.go
@@ -56,7 +56,7 @@ func (c *config) setBackendConfigURL(url string) {
 //			})
 func WithUserTransformations(transformations map[string]string, cleaner resource.Cleaner) func(*config) {
 	return func(conf *config) {
-		backendConfigSvc := NewTestBackendConfigServer(transformations)
+		backendConfigSvc := newTestBackendConfigServer(transformations)
 
 		conf.setBackendConfigURL(dockerTestHelper.ToInternalDockerHost(backendConfigSvc.URL))
 		conf.extraHosts = append(conf.extraHosts, "host.docker.internal:host-gateway")
@@ -78,7 +78,7 @@ func WithConnectionToHostEnabled() func(*config) {
 // WithConfigBackendURL should not be used with WithUserTransformations option
 func WithConfigBackendURL(url string) func(*config) {
 	return func(conf *config) {
-		conf.setBackendConfigURL(url)
+		conf.setBackendConfigURL(dockerTestHelper.ToInternalDockerHost(url))
 	}
 }
 

--- a/testhelper/docker/resource/transformer/transformer.go
+++ b/testhelper/docker/resource/transformer/transformer.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/samber/lo"
 
-	dockerTestHelper "github.com/rudderlabs/rudder-go-kit/testhelper/docker"
+	dockertesthelper "github.com/rudderlabs/rudder-go-kit/testhelper/docker"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
@@ -58,7 +58,7 @@ func WithUserTransformations(transformations map[string]string, cleaner resource
 	return func(conf *config) {
 		backendConfigSvc := newTestBackendConfigServer(transformations)
 
-		conf.setBackendConfigURL(dockerTestHelper.ToInternalDockerHost(backendConfigSvc.URL))
+		conf.setBackendConfigURL(dockertesthelper.ToInternalDockerHost(backendConfigSvc.URL))
 		conf.extraHosts = append(conf.extraHosts, "host.docker.internal:host-gateway")
 		cleaner.Cleanup(func() {
 			backendConfigSvc.Close()
@@ -78,7 +78,7 @@ func WithConnectionToHostEnabled() func(*config) {
 // WithConfigBackendURL should not be used with WithUserTransformations option
 func WithConfigBackendURL(url string) func(*config) {
 	return func(conf *config) {
-		conf.setBackendConfigURL(dockerTestHelper.ToInternalDockerHost(url))
+		conf.setBackendConfigURL(dockertesthelper.ToInternalDockerHost(url))
 	}
 }
 

--- a/testhelper/docker/resource/transformer/transformer_backend_config.go
+++ b/testhelper/docker/resource/transformer/transformer_backend_config.go
@@ -14,10 +14,15 @@ const (
 	versionIDKey           = "versionId"
 )
 
-func NewTestBackendConfigServer(transformations map[string]string) *kithttptest.Server {
+func newTestBackendConfigServer(transformations map[string]string) *kithttptest.Server {
+	return kithttptest.NewServer(NewTransformerBackendConfigHandler(transformations))
+}
+
+// NewTransformerBackendConfigHandler returns http request handler to handle all backend config requests by transformer
+func NewTransformerBackendConfigHandler(transformations map[string]string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc(getByVersionIdEndPoint, getByVersionIdHandler(transformations))
-	return kithttptest.NewServer(mux)
+	return mux
 }
 
 func getByVersionIdHandler(transformations map[string]string) func(http.ResponseWriter, *http.Request) {

--- a/testhelper/httptest/httptest.go
+++ b/testhelper/httptest/httptest.go
@@ -10,7 +10,7 @@ import (
 // NewServer starts a new httptest server that listens on all interfaces, contrary to the standard net/httptest.Server that listens only on localhost.
 // This is useful when you want to access the test http server from within a docker container.
 func NewServer(handler http.Handler) *Server {
-	ts := newUnStartedServer(handler)
+	ts := NewUnStartedServer(handler)
 	ts.start()
 	return ts
 }
@@ -29,7 +29,7 @@ func (s *Server) start() {
 	s.URL = fmt.Sprintf("http://%s:%s", "localhost", port)
 }
 
-func newUnStartedServer(handler http.Handler) *Server {
+func NewUnStartedServer(handler http.Handler) *Server {
 	return &Server{&nethttptest.Server{
 		Listener: newListener(),
 		Config:   &http.Server{Handler: handler},

--- a/testhelper/httptest/httptest_test.go
+++ b/testhelper/httptest/httptest_test.go
@@ -58,7 +58,7 @@ func TestUnStartedServer(t *testing.T) {
 		resp, err := http.Get("http://" + httpUnStartedServer.Listener.Addr().String())
 		defer func() { httputil.CloseResponse(resp) }()
 		return err == nil
-	}, 5*time.Second, time.Second, "connected to an un-started server")
+	}, 5*time.Second, 10*time.Millisecond, "connected to an un-started server")
 
 	// start the server now
 	httpUnStartedServer.Start()
@@ -72,7 +72,7 @@ func TestUnStartedServer(t *testing.T) {
 			body, err = io.ReadAll(resp.Body)
 		}
 		return err == nil
-	}, 5*time.Second, time.Second, "failed to connect to server")
+	}, 2*time.Second, 100*time.Millisecond, "failed to connect to server")
 
 	require.Equal(t, http.StatusOK, statusCode)
 	require.Equal(t, "Hello, world!", string(body))

--- a/testhelper/httptest/httptest_test.go
+++ b/testhelper/httptest/httptest_test.go
@@ -43,3 +43,41 @@ func TestServer(t *testing.T) {
 	require.Equal(t, http.StatusOK, statusCode)
 	require.Equal(t, "Hello, world!", string(body))
 }
+
+func TestUnStartedServer(t *testing.T) {
+	// create a server which is not started
+	httpUnStartedServer := kithttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Hello, world!"))
+	}))
+
+	var (
+		body       []byte
+		statusCode int
+	)
+	require.Never(t, func() bool {
+		resp, err := http.Get(httpUnStartedServer.URL)
+		defer func() { httputil.CloseResponse(resp) }()
+		if err == nil {
+			statusCode = resp.StatusCode
+			body, err = io.ReadAll(resp.Body)
+		}
+		return err == nil
+	}, 5*time.Second, time.Second, "connected to an un-started server")
+
+	// start the server now
+	httpUnStartedServer.Start()
+	defer httpUnStartedServer.Close()
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(httpUnStartedServer.URL)
+		defer func() { httputil.CloseResponse(resp) }()
+		if err == nil {
+			statusCode = resp.StatusCode
+			body, err = io.ReadAll(resp.Body)
+		}
+		return err == nil
+	}, 5*time.Second, time.Second, "failed to connect to server")
+
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, "Hello, world!", string(body))
+}

--- a/testhelper/httptest/httptest_test.go
+++ b/testhelper/httptest/httptest_test.go
@@ -46,7 +46,7 @@ func TestServer(t *testing.T) {
 
 func TestUnStartedServer(t *testing.T) {
 	// create a server which is not started
-	httpUnStartedServer := kithttptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	httpUnStartedServer := kithttptest.NewUnStartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("Hello, world!"))
 	}))
 
@@ -55,12 +55,8 @@ func TestUnStartedServer(t *testing.T) {
 		statusCode int
 	)
 	require.Never(t, func() bool {
-		resp, err := http.Get(httpUnStartedServer.URL)
+		resp, err := http.Get("http://" + httpUnStartedServer.Listener.Addr().String())
 		defer func() { httputil.CloseResponse(resp) }()
-		if err == nil {
-			statusCode = resp.StatusCode
-			body, err = io.ReadAll(resp.Body)
-		}
 		return err == nil
 	}, 5*time.Second, time.Second, "connected to an un-started server")
 


### PR DESCRIPTION
Blocking https://github.com/rudderlabs/rudder-server/pull/4473

# Description

- Export http request handler for BE Config, so that if someone wants to implement its own http client for BE Config for transformer need not to implement their own handler again.
- Export NewUnstartedHttpServer to initialise a server that will be started(start serving request) at a later point in time

## Linear Ticket
https://linear.app/rudderstack/issue/PIPE-884/move-backend-config-unavailability-test-to-rudder-server-integration

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.