### PR TITLE
fix: health check for ssh server

### DIFF
--- a/testhelper/docker/resource/sshserver/sshserver.go
+++ b/testhelper/docker/resource/sshserver/sshserver.go
@@ -98,7 +98,7 @@ func Setup(pool *dockertest.Pool, cln resource.Cleaner, opts ...Option) (*Resour
 	}
 	container, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "lscr.io/linuxserver/openssh-server",
-		Tag:        "latest",
+		Tag:        "9.3_p2-r1-ls145",
 		NetworkID:  network.ID,
 		Hostname:   "sshserver",
 		PortBindings: map[dc.Port][]dc.PortBinding{


### PR DESCRIPTION
# Description

- There seem to be some changes made in the latest docker image which was published 4 days back. I tried with an older image [9.3_p2-r1-ls145](https://hub.docker.com/layers/linuxserver/openssh-server/9.3_p2-r1-ls145/images/sha256-518b05c43d45a515f5e78b3f822f25884afd2ddfa396ff430e6fb1ed7dd8ad02?context=explore) and it's working there.

## Linear Ticket

- Resolves PIPE-966, PIPE-962

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used