### PR TITLE
feat: throttling with retryAfter

### DIFF
--- a/throttling/lua/gcra.lua
+++ b/throttling/lua/gcra.lua
@@ -51,8 +51,8 @@ if remaining < 0 then
         current_time_micro,
         0, -- allowed
         0, -- remaining
-        tostring(retry_after),
-        tostring(reset_after),
+        tonumber(retry_after),
+        tonumber(reset_after),
     }
 end
 
@@ -62,4 +62,4 @@ if reset_after > 0 then
 end
 
 local retry_after = -1
-return { current_time_micro, cost, remaining, tostring(retry_after), tostring(reset_after) }
+return { current_time_micro, cost, remaining, tonumber(retry_after), tonumber(reset_after) }

--- a/throttling/memory_gcra.go
+++ b/throttling/memory_gcra.go
@@ -20,19 +20,19 @@ type gcra struct {
 }
 
 func (g *gcra) limit(ctx context.Context, key string, cost, burst, rate, period int64) (
-	bool, error,
+	bool, time.Duration, error,
 ) {
 	rl, err := g.getLimiter(key, burst, rate, period)
 	if err != nil {
-		return false, err
+		return false, 0, err
 	}
 
-	limited, _, err := rl.RateLimitCtx(ctx, "key", int(cost))
+	limited, res, err := rl.RateLimitCtx(ctx, "key", int(cost))
 	if err != nil {
-		return false, fmt.Errorf("could not rate limit: %w", err)
+		return false, 0, fmt.Errorf("could not rate limit: %w", err)
 	}
 
-	return !limited, nil
+	return !limited, res.RetryAfter, nil
 }
 
 func (g *gcra) getLimiter(key string, burst, rate, period int64) (*throttled.GCRARateLimiterCtx, error) {

--- a/throttling/memory_gcra_test.go
+++ b/throttling/memory_gcra_test.go
@@ -16,7 +16,7 @@ func TestMemoryGCRA(t *testing.T) {
 		rate := int64(1)
 		period := int64(1)
 
-		allowed, err := l.limit(context.Background(), "key", burst+rate, burst, rate, period)
+		allowed, _, err := l.limit(context.Background(), "key", burst+rate, burst, rate, period)
 		require.NoError(t, err)
 		require.True(t, allowed, "it should be able to fill the bucket (burst)")
 
@@ -24,7 +24,7 @@ func TestMemoryGCRA(t *testing.T) {
 		start := time.Now()
 
 		require.Eventually(t, func() bool {
-			allowed, err := l.limit(context.Background(), "key", burst, burst, rate, period)
+			allowed, _, err := l.limit(context.Background(), "key", burst, burst, rate, period)
 			if err != nil {
 				t.Logf("Memory GCRA error: %v", err)
 				return false

--- a/throttling/throttling.go
+++ b/throttling/throttling.go
@@ -201,7 +201,7 @@ func (l *Limiter) redisGCRA(ctx context.Context, cost, rate, window int64, key s
 		if !ok {
 			return redisTime, false, 0, nil, fmt.Errorf("unexpected result[3] from GCRA Redis script of type %T: %v", result[3], result[3])
 		}
-		return redisTime, false, time.Duration(retryAfter), nil, nil
+		return redisTime, false, time.Duration(retryAfter) * time.Microsecond, nil, nil
 	}
 
 	r := &unsupportedReturn{}

--- a/throttling/throttling.go
+++ b/throttling/throttling.go
@@ -79,63 +79,83 @@ func New(options ...Option) (*Limiter, error) {
 func (l *Limiter) Allow(ctx context.Context, cost, rate, window int64, key string) (
 	bool, func(context.Context) error, error,
 ) {
+	allowed, _, tr, err := l.allow(ctx, cost, rate, window, key)
+	return allowed, tr, err
+}
+
+// AllowAfter returns true if the limit is not exceeded, false otherwise.
+// Additionally, it returns the time.Duration until the next allowed request.
+func (l *Limiter) AllowAfter(ctx context.Context, cost, rate, window int64, key string) (
+	bool, time.Duration, func(context.Context) error, error,
+) {
+	return l.allow(ctx, cost, rate, window, key)
+}
+
+func (l *Limiter) allow(ctx context.Context, cost, rate, window int64, key string) (
+	bool, time.Duration, func(context.Context) error, error,
+) {
 	if cost < 1 {
-		return false, nil, fmt.Errorf("cost must be greater than 0")
+		return false, 0, nil, fmt.Errorf("cost must be greater than 0")
 	}
 	if rate < 1 {
-		return false, nil, fmt.Errorf("rate must be greater than 0")
+		return false, 0, nil, fmt.Errorf("rate must be greater than 0")
 	}
 	if window < 1 {
-		return false, nil, fmt.Errorf("window must be greater than 0")
+		return false, 0, nil, fmt.Errorf("window must be greater than 0")
 	}
 	if key == "" {
-		return false, nil, fmt.Errorf("key must not be empty")
+		return false, 0, nil, fmt.Errorf("key must not be empty")
 	}
 
 	if l.redisSpeaker != nil {
 		if l.useGCRA {
 			defer l.getTimer(key, "redis-gcra", rate, window)()
-			_, allowed, tr, err := l.redisGCRA(ctx, cost, rate, window, key)
-			return allowed, tr, err
+			_, allowed, retryAfter, tr, err := l.redisGCRA(ctx, cost, rate, window, key)
+			return allowed, retryAfter, tr, err
 		}
 
 		defer l.getTimer(key, "redis-sorted-set", rate, window)()
-		_, allowed, tr, err := l.redisSortedSet(ctx, cost, rate, window, key)
-		return allowed, tr, err
+		_, allowed, retryAfter, tr, err := l.redisSortedSet(ctx, cost, rate, window, key)
+		return allowed, retryAfter, tr, err
 	}
 
 	defer l.getTimer(key, "gcra", rate, window)()
-	return l.gcraLimit(ctx, cost, rate, window, key)
+	allowed, retryAfter, tr, err := l.gcraLimit(ctx, cost, rate, window, key)
+	return allowed, retryAfter, tr, err
 }
 
 func (l *Limiter) redisSortedSet(ctx context.Context, cost, rate, window int64, key string) (
-	time.Duration, bool, func(context.Context) error, error,
+	time.Duration, bool, time.Duration, func(context.Context) error, error,
 ) {
 	res, err := sortedSetScript.Run(ctx, l.redisSpeaker, []string{key}, cost, rate, window).Result()
 	if err != nil {
-		return 0, false, nil, fmt.Errorf("could not run SortedSet Redis script: %v", err)
+		return 0, false, 0, nil, fmt.Errorf("could not run SortedSet Redis script: %v", err)
 	}
 
 	result, ok := res.([]interface{})
 	if !ok {
-		return 0, false, nil, fmt.Errorf("unexpected result from SortedSet Redis script of type %T: %v", res, res)
+		return 0, false, 0, nil, fmt.Errorf("unexpected result from SortedSet Redis script of type %T: %v", res, res)
 	}
-	if len(result) != 2 {
-		return 0, false, nil, fmt.Errorf("unexpected result from SortedSet Redis script of length %d: %+v", len(result), result)
+	if len(result) != 3 {
+		return 0, false, 0, nil, fmt.Errorf("unexpected result from SortedSet Redis script of length %d: %+v", len(result), result)
 	}
 
 	t, ok := result[0].(int64)
 	if !ok {
-		return 0, false, nil, fmt.Errorf("unexpected result[0] from SortedSet Redis script of type %T: %v", result[0], result[0])
+		return 0, false, 0, nil, fmt.Errorf("unexpected result[0] from SortedSet Redis script of type %T: %v", result[0], result[0])
 	}
 	redisTime := time.Duration(t) * time.Microsecond
 
 	members, ok := result[1].(string)
 	if !ok {
-		return redisTime, false, nil, fmt.Errorf("unexpected result[1] from SortedSet Redis script of type %T: %v", result[1], result[1])
+		return redisTime, false, 0, nil, fmt.Errorf("unexpected result[1] from SortedSet Redis script of type %T: %v", result[1], result[1])
 	}
 	if members == "" { // limit exceeded
-		return redisTime, false, nil, nil
+		retryAfter, ok := result[2].(int64)
+		if !ok {
+			return redisTime, false, 0, nil, fmt.Errorf("unexpected result[2] from SortedSet Redis script of type %T: %v", result[2], result[2])
+		}
+		return redisTime, false, time.Duration(retryAfter), nil, nil
 	}
 
 	r := &sortedSetRedisReturn{
@@ -143,11 +163,11 @@ func (l *Limiter) redisSortedSet(ctx context.Context, cost, rate, window int64, 
 		members: strings.Split(members, ","),
 		remover: l.redisSpeaker,
 	}
-	return redisTime, true, r.Return, nil
+	return redisTime, true, 0, r.Return, nil
 }
 
 func (l *Limiter) redisGCRA(ctx context.Context, cost, rate, window int64, key string) (
-	time.Duration, bool, func(context.Context) error, error,
+	time.Duration, bool, time.Duration, func(context.Context) error, error,
 ) {
 	burst := rate
 	if l.gcraBurst > 0 {
@@ -155,51 +175,55 @@ func (l *Limiter) redisGCRA(ctx context.Context, cost, rate, window int64, key s
 	}
 	res, err := gcraRedisScript.Run(ctx, l.redisSpeaker, []string{key}, burst, rate, window, cost).Result()
 	if err != nil {
-		return 0, false, nil, fmt.Errorf("could not run GCRA Redis script: %v", err)
+		return 0, false, 0, nil, fmt.Errorf("could not run GCRA Redis script: %v", err)
 	}
 
-	result, ok := res.([]interface{})
+	result, ok := res.([]any)
 	if !ok {
-		return 0, false, nil, fmt.Errorf("unexpected result from GCRA Redis script of type %T: %v", res, res)
+		return 0, false, 0, nil, fmt.Errorf("unexpected result from GCRA Redis script of type %T: %v", res, res)
 	}
 	if len(result) != 5 {
-		return 0, false, nil, fmt.Errorf("unexpected result from GCRA Redis scrip of length %d: %+v", len(result), result)
+		return 0, false, 0, nil, fmt.Errorf("unexpected result from GCRA Redis scrip of length %d: %+v", len(result), result)
 	}
 
 	t, ok := result[0].(int64)
 	if !ok {
-		return 0, false, nil, fmt.Errorf("unexpected result[0] from GCRA Redis script of type %T: %v", result[0], result[0])
+		return 0, false, 0, nil, fmt.Errorf("unexpected result[0] from GCRA Redis script of type %T: %v", result[0], result[0])
 	}
 	redisTime := time.Duration(t) * time.Microsecond
 
 	allowed, ok := result[1].(int64)
 	if !ok {
-		return redisTime, false, nil, fmt.Errorf("unexpected result[1] from GCRA Redis script of type %T: %v", result[1], result[1])
+		return redisTime, false, 0, nil, fmt.Errorf("unexpected result[1] from GCRA Redis script of type %T: %v", result[1], result[1])
 	}
 	if allowed < 1 { // limit exceeded
-		return redisTime, false, nil, nil
+		retryAfter, ok := result[3].(int64)
+		if !ok {
+			return redisTime, false, 0, nil, fmt.Errorf("unexpected result[3] from GCRA Redis script of type %T: %v", result[3], result[3])
+		}
+		return redisTime, false, time.Duration(retryAfter), nil, nil
 	}
 
 	r := &unsupportedReturn{}
-	return redisTime, true, r.Return, nil
+	return redisTime, true, 0, r.Return, nil
 }
 
 func (l *Limiter) gcraLimit(ctx context.Context, cost, rate, window int64, key string) (
-	bool, func(context.Context) error, error,
+	bool, time.Duration, func(context.Context) error, error,
 ) {
 	burst := rate
 	if l.gcraBurst > 0 {
 		burst = l.gcraBurst
 	}
-	allowed, err := l.gcra.limit(ctx, key, cost, burst, rate, window)
+	allowed, retryAfter, err := l.gcra.limit(ctx, key, cost, burst, rate, window)
 	if err != nil {
-		return false, nil, fmt.Errorf("could not limit: %w", err)
+		return false, 0, nil, fmt.Errorf("could not limit: %w", err)
 	}
 	if !allowed {
-		return false, nil, nil // limit exceeded
+		return false, retryAfter, nil, nil // limit exceeded
 	}
 	r := &unsupportedReturn{}
-	return true, r.Return, nil
+	return true, 0, r.Return, nil
 }
 
 func (l *Limiter) getTimer(key, algo string, rate, window int64) func() {

--- a/throttling/throttling.go
+++ b/throttling/throttling.go
@@ -155,7 +155,7 @@ func (l *Limiter) redisSortedSet(ctx context.Context, cost, rate, window int64, 
 		if !ok {
 			return redisTime, false, 0, nil, fmt.Errorf("unexpected result[2] from SortedSet Redis script of type %T: %v", result[2], result[2])
 		}
-		return redisTime, false, time.Duration(retryAfter), nil, nil
+		return redisTime, false, time.Duration(retryAfter) * time.Microsecond, nil, nil
 	}
 
 	r := &sortedSetRedisReturn{

--- a/throttling/throttling_test.go
+++ b/throttling/throttling_test.go
@@ -345,9 +345,9 @@ func TestRetryAfter(t *testing.T) {
 				runFor:                    3 * time.Second,
 				warmUp:                    false,
 				expectedAllowedCount:      6,
-				expectedAllowedCountDelta: 0,
+				expectedAllowedCountDelta: 0, // this algorithm is the most precise but requires more memory on Redis
 				expectedSleepsCount:       3,
-				expectedSleepsCountDelta:  0,
+				expectedSleepsCountDelta:  0, // this algorithm is the most precise but requires more memory on Redis
 			},
 		}
 	)

--- a/throttling/throttling_test.go
+++ b/throttling/throttling_test.go
@@ -291,11 +291,6 @@ func TestRetryAfter(t *testing.T) {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 
-	type limiterSettings struct {
-		name    string
-		limiter *Limiter
-	}
-
 	type testCase struct {
 		name                      string
 		limiter                   *Limiter


### PR DESCRIPTION
# Description

Adding support for `retryAfter` to all throttling algorithms.

This should be useful in the src-router for example where we want to estabilish a consumption rate throttling mechanism.

Without this we would be limited to in-memory algorithms only and we would have to spam the CPU by calling `Allow()` in a loop until we get `true`. 

Thanks to `retryAfter`, once we get `false` (we hit the limit) we can simply sleep for the amount of microseconds specified by the algorithm and then, at the next call, we should be allowed to get through. Unfortunately the GCRA algorithms aren't very precise so sometimes we might get throttled regardless of the sleep. With the "sorted set" algorithm this never happens (in single-threaded programs).

### Sidenotes
* The existing API has not been changed. I have instead added a new method `AllowAfter` to avoid breaking changes.

## Linear Ticket

< [Linear_Link](https://linear.app/rudderstack/issue/PIPE-976/throttling-with-retryafter) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
