### PR TITLE
feat: add remoteFilePath support and create remote directory in sftp

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -87,6 +87,7 @@ type Client interface {
 	Create(path string) (io.WriteCloser, error)
 	Open(path string) (io.ReadCloser, error)
 	Remove(path string) error
+	MkdirAll(path string) error
 }
 
 // newSFTPClient creates an SFTP client with existing SSH client
@@ -110,4 +111,8 @@ func (c *clientImpl) Open(path string) (io.ReadCloser, error) {
 
 func (c *clientImpl) Remove(path string) error {
 	return c.client.Remove(path)
+}
+
+func (c *clientImpl) MkdirAll(path string) error {
+	return c.client.MkdirAll(path)
 }

--- a/sftp/mock_sftp/mock_sftp_client.go
+++ b/sftp/mock_sftp/mock_sftp_client.go
@@ -49,6 +49,20 @@ func (mr *MockClientMockRecorder) Create(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), arg0)
 }
 
+// MkdirAll mocks base method.
+func (m *MockClient) MkdirAll(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MkdirAll", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MkdirAll indicates an expected call of MkdirAll.
+func (mr *MockClientMockRecorder) MkdirAll(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockClient)(nil).MkdirAll), arg0)
+}
+
 // Open mocks base method.
 func (m *MockClient) Open(arg0 string) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
@@ -76,18 +90,4 @@ func (m *MockClient) Remove(arg0 string) error {
 func (mr *MockClientMockRecorder) Remove(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockClient)(nil).Remove), arg0)
-}
-
-// MkdirAll mocks base method.
-func (m *MockClient) MkdirAll(arg0 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MkdirAll", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// MkdirAll indicates an expected call of MkdirAll.
-func (mr *MockClientMockRecorder) MkdirAll(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockClient)(nil).MkdirAll), arg0)
 }

--- a/sftp/mock_sftp/mock_sftp_client.go
+++ b/sftp/mock_sftp/mock_sftp_client.go
@@ -77,3 +77,17 @@ func (mr *MockClientMockRecorder) Remove(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockClient)(nil).Remove), arg0)
 }
+
+// MkdirAll mocks base method.
+func (m *MockClient) MkdirAll(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MkdirAll", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MkdirAll indicates an expected call of MkdirAll.
+func (mr *MockClientMockRecorder) MkdirAll(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockClient)(nil).MkdirAll), arg0)
+}

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -37,7 +37,7 @@ func NewFileManager(sshClient *ssh.Client) (FileManager, error) {
 }
 
 // Upload uploads a file to the remote server
-func (fm *fileManagerImpl) Upload(localFilePath, remoteDir string) error {
+func (fm *fileManagerImpl) Upload(localFilePath, remoteFilePath string) error {
 	localFile, err := os.Open(localFilePath)
 	if err != nil {
 		return fmt.Errorf("cannot open local file: %w", err)
@@ -47,12 +47,12 @@ func (fm *fileManagerImpl) Upload(localFilePath, remoteDir string) error {
 	}()
 
 	// Create the directory if it does not exist
+	remoteDir := filepath.Dir(remoteFilePath)
 	if err := fm.client.MkdirAll(remoteDir); err != nil {
 		return fmt.Errorf("cannot create remote directory: %w", err)
 	}
 
-	remoteFileName := filepath.Join(remoteDir, filepath.Base(localFilePath))
-	remoteFile, err := fm.client.Create(remoteFileName)
+	remoteFile, err := fm.client.Create(remoteFilePath)
 	if err != nil {
 		return fmt.Errorf("cannot create remote file: %w", err)
 	}

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -46,6 +46,11 @@ func (fm *fileManagerImpl) Upload(localFilePath, remoteDir string) error {
 		_ = localFile.Close()
 	}()
 
+	// Create the directory if it does not exist
+	if err := fm.client.MkdirAll(remoteDir); err != nil {
+		return fmt.Errorf("cannot create remote directory: %w", err)
+	}
+
 	remoteFileName := filepath.Join(remoteDir, filepath.Base(localFilePath))
 	remoteFile, err := fm.client.Create(remoteFileName)
 	if err != nil {

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -138,6 +138,7 @@ func TestUpload(t *testing.T) {
 
 	mockSFTPClient := mock_sftp.NewMockClient(ctrl)
 	mockSFTPClient.EXPECT().Create(gomock.Any()).Return(&nopWriteCloser{remoteBuf}, nil)
+	mockSFTPClient.EXPECT().MkdirAll(gomock.Any()).Return(nil)
 
 	fileManager := &fileManagerImpl{client: mockSFTPClient}
 

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -142,7 +142,7 @@ func TestUpload(t *testing.T) {
 
 	fileManager := &fileManagerImpl{client: mockSFTPClient}
 
-	err = fileManager.Upload(localFilePath, "someRemoteDir")
+	err = fileManager.Upload(localFilePath, "someRemotePath")
 	require.NoError(t, err)
 	require.Equal(t, data, remoteBuf.Bytes())
 }
@@ -227,7 +227,7 @@ func TestSFTP(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = session.Close() }()
 
-	remoteDir := filepath.Join("/tmp", "remote")
+	remoteDir := filepath.Join("/tmp", "remote", "data")
 	err = session.Run(fmt.Sprintf("mkdir -p %s", remoteDir))
 	require.NoError(t, err)
 
@@ -253,7 +253,7 @@ func TestSFTP(t *testing.T) {
 	err = os.WriteFile(localFilePath, data, 0o644)
 	require.NoError(t, err)
 
-	err = sftpManger.Upload(localFilePath, remoteDir)
+	err = sftpManger.Upload(localFilePath, remoteFilePath)
 	require.NoError(t, err)
 
 	err = sftpManger.Download(remoteFilePath, baseDir)


### PR DESCRIPTION
# Description

- Added support for remote file paths in function parameter and removed support for remote directory parameter.
- The remote file path parameter provides more flexibility. Since it will be an input in the UI, we can directly pass it to the Upload function, whereas with the remote directory, we had to explicitly build the path.
- Create a remote directory if it does not exist.

## Linear Ticket
Resolved INT-2048
https://linear.app/rudderstack/issue/INT-2048/go-kit-create-remote-directory-in-sftp

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
