### PR TITLE
feat: monitor sql database

### DIFF
--- a/sqlutil/monitor.go
+++ b/sqlutil/monitor.go
@@ -1,0 +1,52 @@
+package sqlutil
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+)
+
+// MonitorDatabase collects database connection pool metrics at regular intervals
+func MonitorDatabase(
+	ctx context.Context,
+	conf *config.Config,
+	statsFactory stats.Stats,
+	db *sql.DB,
+	dbIdentifier string,
+) {
+	reportInterval := conf.GetDurationVar(10, time.Second, "Database.ReportInterval", dbIdentifier+".Database.ReportInterval")
+
+	maxOpenConnectionsStat := statsFactory.NewStat(dbIdentifier+".db.max_open_connections", stats.CountType)
+	openConnectionsStat := statsFactory.NewStat(dbIdentifier+".db.open_connections", stats.CountType)
+	inUseStat := statsFactory.NewStat(dbIdentifier+".db.in_use", stats.CountType)
+	idleStat := statsFactory.NewStat(dbIdentifier+".db.idle", stats.CountType)
+	waitCountStat := statsFactory.NewStat(dbIdentifier+".db.wait_count", stats.CountType)
+	waitDurationStat := statsFactory.NewStat(dbIdentifier+".db.wait_duration", stats.TimerType)
+	maxIdleClosedStat := statsFactory.NewStat(dbIdentifier+".db.max_idle_closed", stats.CountType)
+	maxIdleTimeClosedStat := statsFactory.NewStat(dbIdentifier+".db.max_idle_time_closed", stats.CountType)
+	maxLifetimeClosedStat := statsFactory.NewStat(dbIdentifier+".db.max_lifetime_closed", stats.CountType)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(reportInterval):
+				dbStats := db.Stats()
+
+				maxOpenConnectionsStat.Count(dbStats.MaxOpenConnections)
+				openConnectionsStat.Count(dbStats.OpenConnections)
+				inUseStat.Count(dbStats.InUse)
+				idleStat.Count(dbStats.Idle)
+				waitCountStat.Count(int(dbStats.WaitCount))
+				waitDurationStat.SendTiming(dbStats.WaitDuration)
+				maxIdleClosedStat.Count(int(dbStats.MaxIdleClosed))
+				maxIdleTimeClosedStat.Count(int(dbStats.MaxIdleTimeClosed))
+				maxLifetimeClosedStat.Count(int(dbStats.MaxLifetimeClosed))
+			}
+		}
+	}()
+}

--- a/sqlutil/monitor_test.go
+++ b/sqlutil/monitor_test.go
@@ -1,0 +1,46 @@
+package sqlutil_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/sqlutil"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/stats/memstats"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/postgres"
+)
+
+func TestMonitorDatabase(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	postgresContainer, err := postgres.Setup(pool, t)
+	require.NoError(t, err)
+
+	postgresContainer.DB.SetMaxOpenConns(10)
+	postgresContainer.DB.SetMaxIdleConns(5)
+
+	statsStore, err := memstats.New()
+	require.NoError(t, err)
+
+	databaseIdentifier := "test"
+
+	conf := config.New()
+	conf.Set(databaseIdentifier+".Database.ReportInterval", "1s")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sqlutil.MonitorDatabase(ctx, conf, statsStore, postgresContainer.DB, "test")
+
+	require.Eventually(t, func() bool {
+		return statsStore.Get(databaseIdentifier+".db.max_open_connections", stats.Tags{}).LastValue() == 10
+	},
+		5*time.Second,
+		100*time.Millisecond,
+	)
+}


### PR DESCRIPTION
# Description

- Adding support for monitoring database ([*sql.DB](https://pkg.go.dev/database/sql#DB)) using the [DBStats](https://pkg.go.dev/database/sql#DBStats) provided.

## Linear Ticket

- Resolves PIPE-894

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
