### PR TITLE
fix: file creation on aws sftp servers

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -84,8 +84,7 @@ type clientImpl struct {
 }
 
 type Client interface {
-	OpenFile(path string, f int) (io.WriteCloser, error)
-	Open(path string) (io.ReadCloser, error)
+	OpenFile(path string, f int) (io.ReadWriteCloser, error)
 	Remove(path string) error
 	MkdirAll(path string) error
 }
@@ -101,12 +100,8 @@ func newSFTPClient(client *ssh.Client) (Client, error) {
 	}, nil
 }
 
-func (c *clientImpl) OpenFile(path string, f int) (io.WriteCloser, error) {
+func (c *clientImpl) OpenFile(path string, f int) (io.ReadWriteCloser, error) {
 	return c.client.OpenFile(path, f)
-}
-
-func (c *clientImpl) Open(path string) (io.ReadCloser, error) {
-	return c.client.Open(path)
 }
 
 func (c *clientImpl) Remove(path string) error {

--- a/sftp/client.go
+++ b/sftp/client.go
@@ -84,7 +84,7 @@ type clientImpl struct {
 }
 
 type Client interface {
-	Create(path string) (io.WriteCloser, error)
+	OpenFile(path string, f int) (io.WriteCloser, error)
 	Open(path string) (io.ReadCloser, error)
 	Remove(path string) error
 	MkdirAll(path string) error
@@ -101,8 +101,8 @@ func newSFTPClient(client *ssh.Client) (Client, error) {
 	}, nil
 }
 
-func (c *clientImpl) Create(path string) (io.WriteCloser, error) {
-	return c.client.Create(path)
+func (c *clientImpl) OpenFile(path string, f int) (io.WriteCloser, error) {
+	return c.client.OpenFile(path, f)
 }
 
 func (c *clientImpl) Open(path string) (io.ReadCloser, error) {

--- a/sftp/mock_sftp/mock_sftp_client.go
+++ b/sftp/mock_sftp/mock_sftp_client.go
@@ -34,21 +34,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
-func (m *MockClient) Create(arg0 string) (io.WriteCloser, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0)
-	ret0, _ := ret[0].(io.WriteCloser)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Create indicates an expected call of Create.
-func (mr *MockClientMockRecorder) Create(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), arg0)
-}
-
 // MkdirAll mocks base method.
 func (m *MockClient) MkdirAll(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -76,6 +61,21 @@ func (m *MockClient) Open(arg0 string) (io.ReadCloser, error) {
 func (mr *MockClientMockRecorder) Open(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockClient)(nil).Open), arg0)
+}
+
+// OpenFile mocks base method.
+func (m *MockClient) OpenFile(arg0 string, arg1 int) (io.WriteCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenFile", arg0, arg1)
+	ret0, _ := ret[0].(io.WriteCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenFile indicates an expected call of OpenFile.
+func (mr *MockClientMockRecorder) OpenFile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenFile", reflect.TypeOf((*MockClient)(nil).OpenFile), arg0, arg1)
 }
 
 // Remove mocks base method.

--- a/sftp/mock_sftp/mock_sftp_client.go
+++ b/sftp/mock_sftp/mock_sftp_client.go
@@ -48,26 +48,11 @@ func (mr *MockClientMockRecorder) MkdirAll(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockClient)(nil).MkdirAll), arg0)
 }
 
-// Open mocks base method.
-func (m *MockClient) Open(arg0 string) (io.ReadCloser, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Open", arg0)
-	ret0, _ := ret[0].(io.ReadCloser)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Open indicates an expected call of Open.
-func (mr *MockClientMockRecorder) Open(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockClient)(nil).Open), arg0)
-}
-
 // OpenFile mocks base method.
-func (m *MockClient) OpenFile(arg0 string, arg1 int) (io.WriteCloser, error) {
+func (m *MockClient) OpenFile(arg0 string, arg1 int) (io.ReadWriteCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenFile", arg0, arg1)
-	ret0, _ := ret[0].(io.WriteCloser)
+	ret0, _ := ret[0].(io.ReadWriteCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -70,7 +70,7 @@ func (fm *fileManagerImpl) Upload(localFilePath, remoteFilePath string) error {
 
 // Download downloads a file from the remote server
 func (fm *fileManagerImpl) Download(remoteFilePath, localDir string) error {
-	remoteFile, err := fm.client.Open(remoteFilePath)
+	remoteFile, err := fm.client.OpenFile(remoteFilePath, os.O_RDONLY)
 	if err != nil {
 		return fmt.Errorf("cannot open remote file: %w", err)
 	}

--- a/sftp/sftp.go
+++ b/sftp/sftp.go
@@ -52,7 +52,7 @@ func (fm *fileManagerImpl) Upload(localFilePath, remoteFilePath string) error {
 		return fmt.Errorf("cannot create remote directory: %w", err)
 	}
 
-	remoteFile, err := fm.client.Create(remoteFilePath)
+	remoteFile, err := fm.client.OpenFile(remoteFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
 	if err != nil {
 		return fmt.Errorf("cannot create remote file: %w", err)
 	}

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/sshserver"
 )
 
-type nopWriteCloser struct {
-	io.Writer
+type nopReadWriteCloser struct {
+	io.ReadWriter
 }
 
-func (nwc *nopWriteCloser) Close() error {
+func (nwc *nopReadWriteCloser) Close() error {
 	return nil
 }
 
@@ -137,7 +137,7 @@ func TestUpload(t *testing.T) {
 	remoteBuf := bytes.NewBuffer(nil)
 
 	mockSFTPClient := mock_sftp.NewMockClient(ctrl)
-	mockSFTPClient.EXPECT().OpenFile(gomock.Any(), gomock.Any()).Return(&nopWriteCloser{remoteBuf}, nil)
+	mockSFTPClient.EXPECT().OpenFile(gomock.Any(), gomock.Any()).Return(&nopReadWriteCloser{remoteBuf}, nil)
 	mockSFTPClient.EXPECT().MkdirAll(gomock.Any()).Return(nil)
 
 	fileManager := &fileManagerImpl{client: mockSFTPClient}
@@ -160,10 +160,9 @@ func TestDownload(t *testing.T) {
 
 	data := []byte(`{"foo": "bar"}`)
 	remoteBuf := bytes.NewBuffer(data)
-	remoteReader := io.NopCloser(remoteBuf)
 
 	mockSFTPClient := mock_sftp.NewMockClient(ctrl)
-	mockSFTPClient.EXPECT().Open(gomock.Any()).Return(remoteReader, nil)
+	mockSFTPClient.EXPECT().OpenFile(gomock.Any(), gomock.Any()).Return(&nopReadWriteCloser{remoteBuf}, nil)
 
 	fileManager := &fileManagerImpl{client: mockSFTPClient}
 

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -137,7 +137,7 @@ func TestUpload(t *testing.T) {
 	remoteBuf := bytes.NewBuffer(nil)
 
 	mockSFTPClient := mock_sftp.NewMockClient(ctrl)
-	mockSFTPClient.EXPECT().Create(gomock.Any()).Return(&nopWriteCloser{remoteBuf}, nil)
+	mockSFTPClient.EXPECT().OpenFile(gomock.Any(), gomock.Any()).Return(&nopWriteCloser{remoteBuf}, nil)
 	mockSFTPClient.EXPECT().MkdirAll(gomock.Any()).Return(nil)
 
 	fileManager := &fileManagerImpl{client: mockSFTPClient}


### PR DESCRIPTION
# Description

**Problem**
- AWS SFTP server do not support opening files read/write at the same time. 
- Using GO SFTP Client `Create`, AWS SFTP server is throwing this error :- `SSH_FX_OP_UNSUPPORTED`
- Similar issue reported while using Create with AWS SFTP server.
     - https://github.com/pkg/sftp/issues/305

**Solution**
- Use Go SFTP [OpenFile](https://forum.golangbridge.org/t/client-create-test-txt-error-ssh-fx-op-unsupported/27284)
- This is compatible with non AWS SFTP servers too.


## Linear Ticket
Resolves INT-2048
https://linear.app/rudderstack/issue/INT-2048/go-kit-sftp-enhancements

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
