### PR TITLE
feat: add support for custom redis docker repository

### DIFF
--- a/testhelper/docker/resource/redis/redis.go
+++ b/testhelper/docker/resource/redis/redis.go
@@ -33,6 +33,7 @@ func WithEnv(envs ...string) Option {
 	}
 }
 
+// WithRepository is used to specify a custom image that should be pulled from the container registry
 func WithRepository(repository string) Option {
 	return func(rc *redisConfig) {
 		rc.repository = repository

--- a/testhelper/docker/resource/redis/redis.go
+++ b/testhelper/docker/resource/redis/redis.go
@@ -60,7 +60,7 @@ func Setup(ctx context.Context, pool *dockertest.Pool, d resource.Cleaner, opts 
 		opt(&conf)
 	}
 	repo := "redis"
-	if conf.repository == "" {
+	if conf.repository != "" {
 		repo = conf.repository
 	}
 	runOptions := &dockertest.RunOptions{

--- a/testhelper/docker/resource/redis/redis.go
+++ b/testhelper/docker/resource/redis/redis.go
@@ -55,17 +55,14 @@ type redisConfig struct {
 
 func Setup(ctx context.Context, pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource, error) {
 	conf := redisConfig{
-		tag: "6",
+		tag:        "6",
+		repository: "redis",
 	}
 	for _, opt := range opts {
 		opt(&conf)
 	}
-	repo := "redis"
-	if conf.repository != "" {
-		repo = conf.repository
-	}
 	runOptions := &dockertest.RunOptions{
-		Repository: repo,
+		Repository: conf.repository,
 		Tag:        conf.tag,
 		Env:        conf.envs,
 		Cmd:        []string{"redis-server"},

--- a/testhelper/docker/resource/redis/redis.go
+++ b/testhelper/docker/resource/redis/redis.go
@@ -33,6 +33,12 @@ func WithEnv(envs ...string) Option {
 	}
 }
 
+func WithRepository(repository string) Option {
+	return func(rc *redisConfig) {
+		rc.repository = repository
+	}
+}
+
 type Resource struct {
 	Addr string
 }
@@ -40,9 +46,10 @@ type Resource struct {
 type Option func(*redisConfig)
 
 type redisConfig struct {
-	tag     string
-	envs    []string
-	cmdArgs []string
+	repository string
+	tag        string
+	envs       []string
+	cmdArgs    []string
 }
 
 func Setup(ctx context.Context, pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource, error) {
@@ -52,8 +59,12 @@ func Setup(ctx context.Context, pool *dockertest.Pool, d resource.Cleaner, opts 
 	for _, opt := range opts {
 		opt(&conf)
 	}
+	repo := "redis"
+	if conf.repository == "" {
+		repo = conf.repository
+	}
 	runOptions := &dockertest.RunOptions{
-		Repository: "redis",
+		Repository: repo,
 		Tag:        conf.tag,
 		Env:        conf.envs,
 		Cmd:        []string{"redis-server"},


### PR DESCRIPTION
# Description

We are supporting loading a custom docker repository for Redis. Now if someone wants to load a custom redis docker repo, they would need to use `WithRepository`

## Linear Ticket

Resolves INT-2095

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
