### PR TITLE
chore: optimise function config.ConfigKeyToEnv

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,6 @@ package config
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -45,12 +44,6 @@ import (
 )
 
 const DefaultEnvPrefix = "RSERVER"
-
-// regular expression matching lowercase letter followed by an uppercase letter
-var camelCaseMatch = regexp.MustCompile("([a-z0-9])([A-Z])")
-
-// regular expression matching uppercase letters contained in environment variable names
-var upperCaseMatch = regexp.MustCompile("^[A-Z0-9_]+$")
 
 // Default is the singleton config instance
 var Default *Config
@@ -341,7 +334,7 @@ func getOrCreatePointer[T configTypes](
 // the replacer cannot detect camelCase keys.
 func (c *Config) bindEnv(key string) {
 	envVar := key
-	if !upperCaseMatch.MatchString(key) {
+	if !isUpperCaseConfigKey(key) {
 		envVar = ConfigKeyToEnv(c.envPrefix, key)
 	}
 	// bind once

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -494,6 +494,9 @@ func TestConfigKeyToEnv(t *testing.T) {
 	require.Equal(t, expected, ConfigKeyToEnv(DefaultEnvPrefix, "KeyVar1Var2"))
 	require.Equal(t, expected, ConfigKeyToEnv(DefaultEnvPrefix, "RSERVER_KEY_VAR1_VAR2"))
 	require.Equal(t, "KEY_VAR1_VAR2", ConfigKeyToEnv(DefaultEnvPrefix, "KEY_VAR1_VAR2"))
+	require.Equal(t, expected, ConfigKeyToEnv(DefaultEnvPrefix, "Key_Var1.Var2"))
+	require.Equal(t, expected, ConfigKeyToEnv(DefaultEnvPrefix, "key_Var1_Var2"))
+	require.Equal(t, "RSERVER_KEY_VAR_1_VAR2", ConfigKeyToEnv(DefaultEnvPrefix, "Key_Var.1.Var2"))
 }
 
 func TestGetEnvThroughViper(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -724,3 +724,13 @@ func TestConfigLoad(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// Benchmark for the original ConfigKeyToEnv function
+func BenchmarkConfigKeyToEnv(b *testing.B) {
+	envPrefix := "MYAPP"
+	configKey := "myConfig.KeyName"
+	for i := 0; i < b.N; i++ {
+		_ = ConfigKeyToEnv(envPrefix, configKey)
+	}
+	b.ReportAllocs()
+}

--- a/config/env.go
+++ b/config/env.go
@@ -4,15 +4,46 @@ package config
 import (
 	"os"
 	"strings"
+	"unicode"
 )
+
+func isUpperCaseConfigKey(s string) bool {
+	for _, ch := range s {
+		if !(ch == '_' || unicode.IsUpper(ch) || unicode.IsDigit(ch)) {
+			return false
+		}
+	}
+	return true
+}
 
 // ConfigKeyToEnv gets the env variable name from a given config key
 func ConfigKeyToEnv(envPrefix, s string) string {
-	if upperCaseMatch.MatchString(s) {
+	// Check if the string is already in upper case format
+	if isUpperCaseConfigKey(s) {
 		return s
 	}
-	snake := camelCaseMatch.ReplaceAllString(s, "${1}_${2}")
-	return envPrefix + "_" + strings.ToUpper(strings.ReplaceAll(snake, ".", "_"))
+
+	// convert camelCase to snake_case
+	var builder strings.Builder
+
+	// Add the prefix
+	builder.WriteString(envPrefix)
+	builder.WriteByte('_')
+
+	// Transform the input string to the desired format
+	for i, r := range s {
+		if r >= 'A' && r <= 'Z' && i > 0 && (s[i-1] >= 'a' && s[i-1] <= 'z' || s[i-1] >= '0' && s[i-1] <= '9') {
+			builder.WriteByte('_')
+		} else if r == '.' {
+			r = '_'
+		}
+		if unicode.IsLetter(r) {
+			r = unicode.ToUpper(r)
+		}
+		builder.WriteRune(r)
+	}
+
+	return builder.String()
 }
 
 // getEnv returns the environment value stored in key variable


### PR DESCRIPTION
# Description
In a 1 hour profile `config.ConfigKeyToEnv` is taking near to 8.4minutes of execution, which can be seen from flame graph.
<img width="1486" alt="image" src="https://github.com/rudderlabs/rudder-go-kit/assets/26831213/4ac8c01f-1d77-42d7-8890-7fa5cdd3a5f0">

Internally this function is using regex which is we can be replaced and performance can be optimised. After replacing regex with simple for loops we can see improvements in the performance. attaching benchmark results here:
```
Old Code:  
BenchmarkConfigKeyToEnv-12    	 1287674	       922.6 ns/op	     265 B/op	      10 allocs/op
New Code: 
BenchmarkConfigKeyToEnv-12    	 9455137	       118.8 ns/op	      56 B/op	       3 allocs/op
```

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1103/optimise-function-configconfigkeytoenv-in-rudder-go-kit

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
