### PR TITLE
feat: introduce a ttl cache for resources

### DIFF
--- a/cachettl/cachettl.go
+++ b/cachettl/cachettl.go
@@ -14,7 +14,7 @@ type Cache[K comparable, V any] struct {
 	mu        sync.Mutex
 	m         map[K]*node[K, V]
 	now       func() time.Time
-	onevicted func(key K, value V)
+	onEvicted func(key K, value V)
 }
 
 type node[K comparable, V any] struct {
@@ -52,8 +52,8 @@ func (c *Cache[K, V]) Get(key K) (zero V) {
 			if c.now().After(cn.expiration) {
 				cn.remove()             // removes a node from the linked list (leaves the map untouched)
 				delete(c.m, cn.key)     // remove node from map too
-				if c.onevicted != nil { // call the OnEvicted callback if it's set
-					c.onevicted(cn.key, cn.value)
+				if c.onEvicted != nil { // call the OnEvicted callback if it's set
+					c.onEvicted(cn.key, cn.value)
 				}
 			} else { // there is nothing else to clean up, no need to iterate further
 				break
@@ -105,8 +105,8 @@ func (c *Cache[K, V]) Put(key K, value V, ttl time.Duration) {
 	c.add(n)
 }
 
-func (c *Cache[K, V]) OnEvicted(onevicted func(key K, value V)) {
-	c.onevicted = onevicted
+func (c *Cache[K, V]) OnEvicted(onEvicted func(key K, value V)) {
+	c.onEvicted = onEvicted
 }
 
 func (c *Cache[K, V]) add(n *node[K, V]) {

--- a/cachettl/cachettl.go
+++ b/cachettl/cachettl.go
@@ -10,10 +10,11 @@ import (
 // the tail node (end) is the node with the highest expiration time
 // Cleanups are done on Get() calls so if Get() is never invoked then Nodes stay in-memory.
 type Cache[K comparable, V any] struct {
-	root *node[K, V]
-	mu   sync.Mutex
-	m    map[K]*node[K, V]
-	now  func() time.Time
+	root      *node[K, V]
+	mu        sync.Mutex
+	m         map[K]*node[K, V]
+	now       func() time.Time
+	onevicted func(key K, value V)
 }
 
 type node[K comparable, V any] struct {
@@ -49,8 +50,11 @@ func (c *Cache[K, V]) Get(key K) (zero V) {
 		cn := c.root.next // start from head since we're sorting by expiration with the highest expiration at the tail
 		for cn != nil && cn != c.root {
 			if c.now().After(cn.expiration) {
-				cn.remove()         // removes a node from the linked list (leaves the map untouched)
-				delete(c.m, cn.key) // remove node from map too
+				cn.remove()             // removes a node from the linked list (leaves the map untouched)
+				delete(c.m, cn.key)     // remove node from map too
+				if c.onevicted != nil { // call the OnEvicted callback if it's set
+					c.onevicted(cn.key, cn.value)
+				}
 			} else { // there is nothing else to clean up, no need to iterate further
 				break
 			}
@@ -99,6 +103,10 @@ func (c *Cache[K, V]) Put(key K, value V, ttl time.Duration) {
 	}
 
 	c.add(n)
+}
+
+func (c *Cache[K, V]) OnEvicted(onevicted func(key K, value V)) {
+	c.onevicted = onevicted
 }
 
 func (c *Cache[K, V]) add(n *node[K, V]) {

--- a/resourcettl/cache.go
+++ b/resourcettl/cache.go
@@ -87,12 +87,10 @@ func (c *Cache[K, R]) Checkout(key K, new func() (R, error)) (resource R, checki
 // Invalidate invalidates the resource for the given key.
 func (c *Cache[K, R]) Invalidate(key K) {
 	defer c.lockKey(key)()
-	c.mu.Lock()
 	resourceID := c.ttlcache.Get(key)
 	if resourceID != "" {
 		c.ttlcache.Put(key, "", -1)
 	}
-	c.mu.Unlock()
 	if resourceID != "" {
 		c.onEvicted(key, resourceID)
 	}

--- a/resourcettl/cache.go
+++ b/resourcettl/cache.go
@@ -81,7 +81,7 @@ func (c *Cache[K, R]) Checkout(key K, new func() (R, error)) (resource R, checki
 		c.checkouts[resourceID]++
 		return r, c.checkinFunc(r, resourceID), nil
 	}
-	return c.newInstance(key, new)
+	return c.newResource(key, new)
 }
 
 // Invalidate invalidates the resource for the given key.
@@ -98,8 +98,8 @@ func (c *Cache[K, R]) Invalidate(key K) {
 	}
 }
 
-// newInstance creates a new resource for the given key.
-func (c *Cache[K, R]) newInstance(key K, new func() (R, error)) (R, func(), error) {
+// newResource creates a new resource for the given key.
+func (c *Cache[K, R]) newResource(key K, new func() (R, error)) (R, func(), error) {
 	r, err := new()
 	if err != nil {
 		return r, nil, err

--- a/resourcettl/cache_test.go
+++ b/resourcettl/cache_test.go
@@ -1,0 +1,174 @@
+package resourcettl_test
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/resourcettl"
+)
+
+func TestCache(t *testing.T) {
+	const key = "key"
+	ttl := 10 * time.Millisecond
+	t.Run("checkout, checkin, then expire", func(t *testing.T) {
+		t.Run("using cleanup", func(t *testing.T) {
+			producer := &MockProducer{}
+			c := resourcettl.NewCache(producer.NewCleanuper, ttl)
+
+			r1, checkin1, err1 := c.Checkout(key)
+			require.NoError(t, err1, "it should be able to create a new resource")
+			require.NotNil(t, r1, "it should return a resource")
+			require.EqualValues(t, 1, producer.instances.Load(), "it should create a new resource")
+
+			r2, checkin2, err2 := c.Checkout(key)
+			require.NoError(t, err2, "it should be able to checkout the same resource")
+			require.NotNil(t, r2, "it should return a resource")
+			require.EqualValues(t, 1, producer.instances.Load(), "it shouldn't create a new resource")
+			require.Equal(t, r1.id, r2.id, "it should return the same resource")
+
+			time.Sleep(ttl + time.Millisecond)
+			checkin1()
+			checkin2()
+
+			r3, checkin3, err3 := c.Checkout(key)
+			require.NoError(t, err3, "it should be able to create a new resource")
+			require.NotNil(t, r3, "it should return a resource")
+			require.EqualValues(t, 2, producer.instances.Load(), "it should create a new resource since the previous one expired")
+			require.NotEqual(t, r1.id, r3.id, "it should return a different resource")
+			time.Sleep(time.Millisecond) // wait for async cleanup
+			require.EqualValues(t, 1, r1.cleanups.Load(), "it should cleanup the expired resource")
+			checkin3()
+		})
+
+		t.Run("using closer", func(t *testing.T) {
+			producer := &MockProducer{}
+			c := resourcettl.NewCache(producer.NewCloser, ttl)
+
+			r1, checkin1, err1 := c.Checkout(key)
+			require.NoError(t, err1, "it should be able to create a new resource")
+			require.NotNil(t, r1, "it should return a resource")
+			require.EqualValues(t, 1, producer.instances.Load(), "it should create a new resource")
+
+			r2, checkin2, err2 := c.Checkout(key)
+			require.NoError(t, err2, "it should be able to checkout the same resource")
+			require.NotNil(t, r2, "it should return a resource")
+			require.EqualValues(t, 1, producer.instances.Load(), "it shouldn't create a new resource")
+			require.Equal(t, r1.id, r2.id, "it should return the same resource")
+
+			time.Sleep(ttl + time.Millisecond)
+			checkin1()
+			checkin2()
+
+			r3, checkin3, err3 := c.Checkout(key)
+			require.NoError(t, err3, "it should be able to create a new resource")
+			require.NotNil(t, r3, "it should return a resource")
+			require.EqualValues(t, 2, producer.instances.Load(), "it should create a new resource since the previous one expired")
+			require.NotEqual(t, r1.id, r3.id, "it should return a different resource")
+			time.Sleep(time.Millisecond) // wait for async cleanup
+			require.EqualValues(t, 1, r1.cleanups.Load(), "it should cleanup the expired resource")
+			checkin3()
+		})
+	})
+
+	t.Run("expire while being used", func(t *testing.T) {
+		producer := &MockProducer{}
+		c := resourcettl.NewCache(producer.NewCleanuper, ttl)
+
+		r1, checkin1, err1 := c.Checkout(key)
+		require.NoError(t, err1, "it should be able to create a new resource")
+		require.NotNil(t, r1, "it should return a resource")
+		require.EqualValues(t, 1, producer.instances.Load(), "it should create a new resource")
+
+		r2, checkin2, err2 := c.Checkout(key)
+		require.NoError(t, err2, "it should be able to checkout the same resource")
+		require.NotNil(t, r2, "it should return a resource")
+		require.EqualValues(t, 1, producer.instances.Load(), "it shouldn't create a new resource")
+		require.Equal(t, r1.id, r2.id, "it should return the same resource")
+
+		time.Sleep(ttl + time.Millisecond) // wait for expiration
+
+		r3, checkin3, err3 := c.Checkout(key)
+		require.NoError(t, err3, "it should be able to return a resource")
+		require.NotNil(t, r3, "it should return a resource")
+		require.EqualValues(t, 2, producer.instances.Load(), "it should create a new resource since the previous one expired")
+		require.NotEqual(t, r1.id, r3.id, "it should return a different resource")
+		require.EqualValues(t, 0, r1.cleanups.Load(), "it shouldn't cleanup the expired resource yet since it is being used by 2 clients")
+		checkin1()
+		time.Sleep(time.Millisecond) // wait for async cleanup
+		require.EqualValues(t, 0, r1.cleanups.Load(), "it shouldn't cleanup the expired resource yet since it is being used by 1 clients")
+		checkin2()
+		time.Sleep(time.Millisecond) // wait for async cleanup
+		require.EqualValues(t, 1, r1.cleanups.Load(), "it should cleanup the expired resource since it is not being used by any client")
+		checkin3()
+	})
+
+	t.Run("invalidate", func(t *testing.T) {
+		producer := &MockProducer{}
+		c := resourcettl.NewCache(producer.NewCleanuper, ttl)
+
+		r1, checkin1, err1 := c.Checkout(key)
+		require.NoError(t, err1, "it should be able to create a new resource")
+		require.NotNil(t, r1, "it should return a resource")
+		require.EqualValues(t, 1, producer.instances.Load(), "it should create a new resource")
+
+		r2, checkin2, err2 := c.Checkout(key)
+		require.NoError(t, err2, "it should be able to checkout the same resource")
+		require.NotNil(t, r2, "it should return a resource")
+		require.EqualValues(t, 1, producer.instances.Load(), "it shouldn't create a new resource")
+		require.Equal(t, r1.id, r2.id, "it should return the same resource")
+
+		c.Invalidate(key)
+
+		r3, checkin3, err3 := c.Checkout(key)
+		require.NoError(t, err3, "it should be able to create a new resource")
+		require.NotNil(t, r3, "it should return a resource")
+		require.EqualValues(t, 2, producer.instances.Load(), "it should create a new resource since the previous one was invalidated")
+		require.NotEqual(t, r1.id, r3.id, "it should return a different resource")
+		time.Sleep(time.Millisecond) // wait for async cleanup
+		require.EqualValues(t, 0, r1.cleanups.Load(), "it shouldn't cleanup the expired resource yet since it is being used by 2 clients")
+		checkin1()
+		time.Sleep(time.Millisecond) // wait for async cleanup
+		require.EqualValues(t, 0, r1.cleanups.Load(), "it shouldn't cleanup the expired resource yet since it is being used by 1 client")
+		checkin2()
+		time.Sleep(time.Millisecond) // wait for async cleanup
+		require.EqualValues(t, 1, r1.cleanups.Load(), "it should cleanup the expired resource")
+		checkin3()
+	})
+}
+
+type MockProducer struct {
+	instances atomic.Int32
+}
+
+func (m *MockProducer) NewCleanuper(_ string) (*cleanuper, error) {
+	m.instances.Add(1)
+	return &cleanuper{id: uuid.NewString()}, nil
+}
+
+func (m *MockProducer) NewCloser(_ string) (*closer, error) {
+	m.instances.Add(1)
+	return &closer{id: uuid.NewString()}, nil
+}
+
+type cleanuper struct {
+	id       string
+	cleanups atomic.Int32
+}
+
+func (m *cleanuper) Cleanup() {
+	m.cleanups.Add(1)
+}
+
+type closer struct {
+	id       string
+	cleanups atomic.Int32
+}
+
+func (m *closer) Close() error {
+	m.cleanups.Add(1)
+	return nil
+}


### PR DESCRIPTION
# Description

Introducing a new specialty cache for resources which need to be closed/cleaned-up after their expiration.

This new cache keeps track of the resources' usage and makes sure that expired resources are not cleaned up while they are still in use and cleaned up only when they are no longer needed.

Internally it uses a `cachettl.Cache` which has been extended with an `OnEvicted` callback.

Resources with any of following methods can be managed by the cache and cleaned up appropriately:
- `Cleanup()`
- `Close()`
- `Close() error`
- `Stop()`
- `Stop() error`

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
