### PR TITLE
feat: utf8 sanitizer

### DIFF
--- a/utf8/sanitize.go
+++ b/utf8/sanitize.go
@@ -1,0 +1,38 @@
+package utf8
+
+import "unicode/utf8"
+
+const replacementChar = string('?')
+
+var replacementCharByte = []byte(replacementChar)[0]
+
+func init() {
+	if len([]byte(replacementChar)) != 1 {
+		panic("replacementChar must be a single-byte character")
+	}
+}
+
+// Sanitize detects invalid UTF-8 byte sequences and replaces them with the replacement character.
+// The slice length remains unchanged and no extra allocations are made.
+func Sanitize(data []byte) {
+	for i := 0; i < len(data); {
+		r, size := utf8.DecodeRune(data[i:])
+		if r == utf8.RuneError && size == 1 {
+			// Replace the invalid byte with the replacement character
+			data[i] = replacementCharByte
+		}
+		i += size
+	}
+}
+
+// Invalid returns true if the input contains invalid UTF-8 byte sequences.
+func Invalid(data []byte) bool {
+	for i := 0; i < len(data); {
+		r, size := utf8.DecodeRune(data[i:])
+		if r == utf8.RuneError && size == 1 {
+			return true
+		}
+		i += size
+	}
+	return false
+}

--- a/utf8/sanitize_test.go
+++ b/utf8/sanitize_test.go
@@ -1,0 +1,44 @@
+package utf8
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeInvalid(t *testing.T) {
+	var (
+		rb      = replacementCharByte
+		hello   = []byte{72, 101, 108, 108, 111}       // Hello
+		world   = []byte{228, 184, 150, 231, 149, 140} // 世界
+		invalid = []byte{0xff, 0xfe, 0xfd}
+	)
+
+	tests := []struct {
+		name     string
+		valid    bool
+		input    []byte
+		expected []byte
+	}{
+		{"valid", true, []byte("Hello 世界"), []byte("Hello 世界")},
+		{"invalid 1", false, invalid, []byte{rb, rb, rb}},
+		{"invalid 2", false, []byte{0xd4, 0x6d}, []byte{rb, 0x6d}}, // pq: invalid byte sequence for encoding "UTF8": 0xd4 0x6d
+		{"mixed", false, append(hello, append(invalid, world...)...), append(hello, append([]byte{rb, rb, rb}, world...)...)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.valid, !Invalid(tt.input))
+
+			inputCopy := make([]byte, len(tt.input)) // Copy to avoid modifying the original input
+			copy(inputCopy, tt.input)
+
+			Sanitize(inputCopy)
+			t.Logf("Sanitize(%s) = %s", tt.input, inputCopy)
+
+			// After sanitization, the result should be valid
+			require.False(t, Invalid(inputCopy))
+			require.Equal(t, tt.expected, inputCopy)
+		})
+	}
+}


### PR DESCRIPTION
# Description

This is needed by the IngestionSvc so that we don't propagate messages with invalid UTF-8 sequences to Pulsar.
If we do propagate them, then the SrcRouter won't be able to push those messages to RudderServer, because then the RudderServer gateway would fail with the following error:

> pq: invalid byte sequence for encoding "UTF8": 0xd4 0x6d

## Linear Ticket

< [Linear_Link](https://linear.app/rudderstack/issue/PIPE-1131/fix-invalid-utf8-bytes-issue-on-ingestionsvc) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
