### PR TITLE
chore: expose otel version from stats library

### DIFF
--- a/stats/otel.go
+++ b/stats/otel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cast"
+	ootel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	noopMetric "go.opentelemetry.io/otel/metric/noop"
@@ -60,6 +61,10 @@ type otelStats struct {
 	httpServerShutdownComplete chan struct{}
 	prometheusRegisterer       prometheus.Registerer
 	prometheusGatherer         prometheus.Gatherer
+}
+
+func OtelVersion() string {
+	return ootel.Version()
 }
 
 func (s *otelStats) Start(ctx context.Context, goFactory GoRoutineFactory) error {


### PR DESCRIPTION
# Description

Exposes otel version so downstream dependencies won't need to import open tel package for testing.

For example here https://github.com/rudderlabs/rudder-server/blob/f4b5d114508db4795e71a13eeb9596c7ebd1838b/integration_test/tracing/tracing_test.go#L692z

rudder-server depending on `go.opentelemetry.io/otel` causes issues when [upgrading dependencies](https://github.com/rudderlabs/rudder-server/pull/4713).

By using exposing otelVersion from stats, we remove this minor unnecessary dependency.

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1123/address-vulnerability-issues

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
