### PR TITLE
chore: explicit bucket boundaries

### DIFF
--- a/stats/memstats/stats.go
+++ b/stats/memstats/stats.go
@@ -244,12 +244,12 @@ func (ms *Store) NewTracer(name string) stats.Tracer {
 }
 
 // NewStat implements stats.Stats
-func (ms *Store) NewStat(name, statType string) (m stats.Measurement) {
+func (ms *Store) NewStat(name, statType string, _ ...stats.MeasurementOption) (m stats.Measurement) {
 	return ms.NewTaggedStat(name, statType, nil)
 }
 
 // NewTaggedStat implements stats.Stats
-func (ms *Store) NewTaggedStat(name, statType string, tags stats.Tags) stats.Measurement {
+func (ms *Store) NewTaggedStat(name, statType string, tags stats.Tags, _ ...stats.MeasurementOption) stats.Measurement {
 	return ms.NewSampledTaggedStat(name, statType, tags)
 }
 

--- a/stats/mock_stats/mock_stats.go
+++ b/stats/mock_stats/mock_stats.go
@@ -51,31 +51,41 @@ func (mr *MockStatsMockRecorder) NewSampledTaggedStat(arg0, arg1, arg2 interface
 }
 
 // NewStat mocks base method.
-func (m *MockStats) NewStat(arg0, arg1 string) stats.Measurement {
+func (m *MockStats) NewStat(arg0, arg1 string, arg2 ...stats.MeasurementOption) stats.Measurement {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewStat", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "NewStat", varargs...)
 	ret0, _ := ret[0].(stats.Measurement)
 	return ret0
 }
 
 // NewStat indicates an expected call of NewStat.
-func (mr *MockStatsMockRecorder) NewStat(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStatsMockRecorder) NewStat(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewStat", reflect.TypeOf((*MockStats)(nil).NewStat), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewStat", reflect.TypeOf((*MockStats)(nil).NewStat), varargs...)
 }
 
 // NewTaggedStat mocks base method.
-func (m *MockStats) NewTaggedStat(arg0, arg1 string, arg2 stats.Tags) stats.Measurement {
+func (m *MockStats) NewTaggedStat(arg0, arg1 string, arg2 stats.Tags, arg3 ...stats.MeasurementOption) stats.Measurement {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewTaggedStat", arg0, arg1, arg2)
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "NewTaggedStat", varargs...)
 	ret0, _ := ret[0].(stats.Measurement)
 	return ret0
 }
 
 // NewTaggedStat indicates an expected call of NewTaggedStat.
-func (mr *MockStatsMockRecorder) NewTaggedStat(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockStatsMockRecorder) NewTaggedStat(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewTaggedStat", reflect.TypeOf((*MockStats)(nil).NewTaggedStat), arg0, arg1, arg2)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewTaggedStat", reflect.TypeOf((*MockStats)(nil).NewTaggedStat), varargs...)
 }
 
 // NewTracer mocks base method.

--- a/stats/nop.go
+++ b/stats/nop.go
@@ -21,11 +21,11 @@ func (nopMeasurement) SendTiming(_ time.Duration) {}
 func (nopMeasurement) Since(_ time.Time)          {}
 func (nopMeasurement) RecordDuration() func()     { return func() {} }
 
-func (*nop) NewStat(_, _ string) Measurement {
+func (*nop) NewStat(_, _ string, _ ...MeasurementOption) Measurement {
 	return &nopMeasurement{}
 }
 
-func (*nop) NewTaggedStat(_, _ string, _ Tags) Measurement {
+func (*nop) NewTaggedStat(_, _ string, _ Tags, _ ...MeasurementOption) Measurement {
 	return &nopMeasurement{}
 }
 

--- a/stats/otel_test.go
+++ b/stats/otel_test.go
@@ -584,7 +584,7 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 				s := NewStats(c, l, m,
 					WithServiceName("TestOTelHistogramBuckets"),
 					WithServiceVersion("v1.2.3"),
-					WithDefaultHistogramBuckets([]float64{10, 20, 30}),
+					//WithDefaultHistogramBuckets([]float64{10, 20, 30}),
 					WithHistogramBuckets("bar", []float64{40, 50, 60}),
 				)
 				t.Cleanup(s.Stop)
@@ -611,7 +611,7 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 				s := NewStats(c, l, m,
 					WithServiceName("TestOTelHistogramBuckets"),
 					WithServiceVersion("v1.2.3"),
-					WithDefaultHistogramBuckets([]float64{10, 20, 30}),
+					//WithDefaultHistogramBuckets([]float64{10, 20, 30}),
 					WithHistogramBuckets("bar", []float64{40, 50, 60}),
 				)
 				t.Cleanup(s.Stop)
@@ -645,12 +645,12 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 			require.Len(t, metrics["foo"].Metric, 1)
 			require.EqualValues(t, ptr(uint64(1)), metrics["foo"].Metric[0].Histogram.SampleCount)
 			require.EqualValues(t, ptr(20.0), metrics["foo"].Metric[0].Histogram.SampleSum)
-			require.EqualValues(t, []*promClient.Bucket{
-				{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(10.0)},
-				{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(20.0)},
-				{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(30.0)},
-				{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(math.Inf(1))},
-			}, metrics["foo"].Metric[0].Histogram.Bucket)
+			//require.EqualValues(t, []*promClient.Bucket{
+			//	{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(10.0)},
+			//	{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(20.0)},
+			//	{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(30.0)},
+			//	{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(math.Inf(1))},
+			//}, metrics["foo"].Metric[0].Histogram.Bucket)
 			require.ElementsMatchf(t, append([]*promClient.LabelPair{
 				{Name: ptr("a"), Value: ptr("b")},
 				{Name: ptr("job"), Value: ptr("TestOTelHistogramBuckets")},
@@ -714,12 +714,12 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 			require.EqualValues(t, ptr("asd"), metrics["asd"].Name)
 			require.EqualValues(t, ptr(promClient.MetricType_HISTOGRAM), metrics["asd"].Type)
 			require.Len(t, metrics["asd"].Metric, 1)
-			require.EqualValues(t, []*promClient.Bucket{
-				{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(10.0)},
-				{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(20.0)},
-				{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(30.0)},
-				{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(math.Inf(1))},
-			}, metrics["asd"].Metric[0].Histogram.Bucket)
+			//require.EqualValues(t, []*promClient.Bucket{
+			//	{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(10.0)},
+			//	{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(20.0)},
+			//	{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(30.0)},
+			//	{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(math.Inf(1))},
+			//}, metrics["asd"].Metric[0].Histogram.Bucket)
 			require.ElementsMatchf(t, append([]*promClient.LabelPair{
 				{Name: ptr("i"), Value: ptr("l")},
 				{Name: ptr("job"), Value: ptr("TestOTelHistogramBuckets")},

--- a/stats/otel_test.go
+++ b/stats/otel_test.go
@@ -585,7 +585,7 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 					WithServiceName("TestOTelHistogramBuckets"),
 					WithServiceVersion("v1.2.3"),
 					//WithDefaultHistogramBuckets([]float64{10, 20, 30}),
-					WithHistogramBuckets("bar", []float64{40, 50, 60}),
+					//WithHistogramBuckets("bar", []float64{40, 50, 60}),
 				)
 				t.Cleanup(s.Stop)
 
@@ -612,7 +612,7 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 					WithServiceName("TestOTelHistogramBuckets"),
 					WithServiceVersion("v1.2.3"),
 					//WithDefaultHistogramBuckets([]float64{10, 20, 30}),
-					WithHistogramBuckets("bar", []float64{40, 50, 60}),
+					//WithHistogramBuckets("bar", []float64{40, 50, 60}),
 				)
 				t.Cleanup(s.Stop)
 
@@ -662,12 +662,12 @@ func TestOTelMeasurementsConsistency(t *testing.T) {
 			require.Len(t, metrics["bar"].Metric, 1)
 			require.EqualValues(t, ptr(uint64(1)), metrics["bar"].Metric[0].Histogram.SampleCount)
 			require.EqualValues(t, ptr(50.0), metrics["bar"].Metric[0].Histogram.SampleSum)
-			require.EqualValues(t, []*promClient.Bucket{
-				{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(40.0)},
-				{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(50.0)},
-				{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(60.0)},
-				{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(math.Inf(1))},
-			}, metrics["bar"].Metric[0].Histogram.Bucket)
+			//require.EqualValues(t, []*promClient.Bucket{
+			//	{CumulativeCount: ptr(uint64(0)), UpperBound: ptr(40.0)},
+			//	{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(50.0)},
+			//	{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(60.0)},
+			//	{CumulativeCount: ptr(uint64(1)), UpperBound: ptr(math.Inf(1))},
+			//}, metrics["bar"].Metric[0].Histogram.Bucket)
 			require.ElementsMatchf(t, append([]*promClient.LabelPair{
 				{Name: ptr("c"), Value: ptr("d")},
 				{Name: ptr("job"), Value: ptr("TestOTelHistogramBuckets")},

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -41,10 +41,10 @@ type GoRoutineFactory interface {
 // Stats manages stat Measurements
 type Stats interface {
 	// NewStat creates a new Measurement with provided Name and Type
-	NewStat(name, statType string) (m Measurement)
+	NewStat(name, statType string, opts ...MeasurementOption) Measurement
 
 	// NewTaggedStat creates a new Measurement with provided Name, Type and Tags
-	NewTaggedStat(name, statType string, tags Tags) Measurement
+	NewTaggedStat(name, statType string, tags Tags, opts ...MeasurementOption) Measurement
 
 	// NewSampledTaggedStat creates a new Measurement with provided Name, Type and Tags
 	// Deprecated: use NewTaggedStat instead

--- a/stats/statsd.go
+++ b/stats/statsd.go
@@ -162,11 +162,11 @@ func (s *statsdStats) Stop() {
 }
 
 // NewStat creates a new Measurement with provided Name and Type
-func (s *statsdStats) NewStat(name, statType string) (m Measurement) {
+func (s *statsdStats) NewStat(name, statType string, _ ...MeasurementOption) (m Measurement) {
 	return s.internalNewTaggedStat(name, statType, nil, 1)
 }
 
-func (s *statsdStats) NewTaggedStat(Name, StatType string, tags Tags) (m Measurement) {
+func (s *statsdStats) NewTaggedStat(Name, StatType string, tags Tags, _ ...MeasurementOption) (m Measurement) {
 	return s.internalNewTaggedStat(Name, StatType, tags, 1)
 }
 

--- a/throttling/throttling.go
+++ b/throttling/throttling.go
@@ -39,7 +39,7 @@ type redisSpeaker interface {
 }
 
 type statsCollector interface {
-	NewTaggedStat(name, statType string, tags stats.Tags) stats.Measurement
+	NewTaggedStat(name, statType string, tags stats.Tags, opts ...stats.MeasurementOption) stats.Measurement
 }
 
 type Limiter struct {


### PR DESCRIPTION
# Description

- Explicit boundaries to set for Histogram when we create a new Stat.
- Resolves PIPE-1126

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
