### PR TITLE
fix: memstats new stat should reuse measurement

### DIFF
--- a/stats/memstats/stats.go
+++ b/stats/memstats/stats.go
@@ -258,6 +258,10 @@ func (ms *Store) NewSampledTaggedStat(name, statType string, tags stats.Tags) st
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
+	if m, found := ms.byKey[ms.getKey(name, tags)]; found {
+		return m
+	}
+
 	m := &Measurement{
 		name:  name,
 		tags:  tags,

--- a/stats/memstats/stats_test.go
+++ b/stats/memstats/stats_test.go
@@ -391,4 +391,22 @@ func TestStats(t *testing.T) {
 		// checking hierarchy
 		require.Equal(t, spans[1].SpanContext.SpanID, spans[0].Parent.SpanID)
 	})
+
+	t.Run("multiple stats with same name and tags", func(t *testing.T) {
+		store, err := memstats.New()
+		require.NoError(t, err)
+
+		name := "testHistogram"
+		store.NewTaggedStat(name, stats.HistogramType, commonTags).Observe(1.0)
+		store.NewTaggedStat(name, stats.HistogramType, commonTags).Observe(2.0)
+
+		require.Equal(t, 2.0, store.Get(name, commonTags).LastValue())
+		require.Equal(t, []float64{1.0, 2.0}, store.Get(name, commonTags).Values())
+
+		require.Equal(t, []memstats.Metric{{
+			Name:   name,
+			Tags:   commonTags,
+			Values: []float64{1.0, 2.0},
+		}}, store.GetByName(name))
+	})
 }


### PR DESCRIPTION
# Description

Found this issue while writing tests for a histogram metric. I did expect to receive 20 measurements for a metric, but instead I got only one.

It turns out that since a new stat was created every time, the measurement was getting overridden. 

Note that this might have a breaking behaviour downstream, but tests that use `.GetAll` or `.GetByName` should have and test all measurements captured.

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1161/fix-memstats-bug

resolves PIPE-1161

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
