### PR TITLE
feat: minio testhelper add content method

### DIFF
--- a/testhelper/docker/resource/minio/minio_test.go
+++ b/testhelper/docker/resource/minio/minio_test.go
@@ -1,6 +1,8 @@
 package minio
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"testing"
 
@@ -52,4 +54,43 @@ func TestMinioResource(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, items, 1)
 	})
+}
+
+func TestMinioContents(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	minioResource, err := Setup(pool, t)
+	require.NoError(t, err)
+
+	_, err = minioResource.Client.PutObject(context.Background(),
+		minioResource.BucketName, "test-bucket/hello.txt", bytes.NewBufferString("hello"), -1, minio.PutObjectOptions{},
+	)
+	require.NoError(t, err)
+
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	_, err = gz.Write([]byte("hello compressed"))
+	require.NoError(t, err)
+	err = gz.Close()
+	require.NoError(t, err)
+
+	_, err = minioResource.Client.PutObject(context.Background(),
+		minioResource.BucketName, "test-bucket/hello.txt.gz", &b, -1, minio.PutObjectOptions{},
+	)
+	require.NoError(t, err)
+
+	_, err = minioResource.Client.PutObject(context.Background(),
+		minioResource.BucketName, "test-bucket/empty", bytes.NewBuffer([]byte{}), -1, minio.PutObjectOptions{},
+	)
+	require.NoError(t, err)
+
+	files, err := minioResource.Contents(context.Background(), "test-bucket/")
+	require.NoError(t, err)
+
+	require.Equal(t, []File{
+		{Key: "test-bucket/empty", Content: ""},
+		{Key: "test-bucket/hello.txt", Content: "hello"},
+		{Key: "test-bucket/hello.txt.gz", Content: "hello compressed"},
+	}, files)
 }

--- a/testhelper/docker/resource/minio/minio_test.go
+++ b/testhelper/docker/resource/minio/minio_test.go
@@ -93,4 +93,12 @@ func TestMinioContents(t *testing.T) {
 		{Key: "test-bucket/hello.txt", Content: "hello"},
 		{Key: "test-bucket/hello.txt.gz", Content: "hello compressed"},
 	}, files)
+
+	t.Run("canceled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := minioResource.Contents(ctx, "test-bucket/")
+		require.ErrorIs(t, err, context.Canceled)
+	})
 }


### PR DESCRIPTION
# Description

Add content method to testhelper minio resource, to avoid code repetition in tests.

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1179/rudder-go-kit-testhelper-miniocontents

resolves PIPE-1179

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
