### PR TITLE
feat: guard for ensuring method will return after ctx cancellation

### DIFF
--- a/guard/stop.go
+++ b/guard/stop.go
@@ -1,0 +1,50 @@
+package guard
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+var defaultGuard = &Guard{}
+
+type Guard struct {
+	Go   func(func())
+	once sync.Once
+}
+
+func (g *Guard) MustStop(ctx context.Context, timeout time.Duration) func() {
+	g.once.Do(func() {
+		if g.Go == nil {
+			g.Go = func(fn func()) {
+				go fn()
+			}
+		}
+	})
+
+	inCtx, cancel := context.WithCancel(context.Background())
+
+	g.Go(func() {
+		select {
+		case <-inCtx.Done():
+			return
+		case <-ctx.Done():
+		}
+
+		timer := time.NewTimer(timeout)
+		select {
+		case <-timer.C:
+			panic("timeout waiting for method stop")
+		case <-inCtx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+		}
+	})
+
+	return cancel
+}
+
+func MustStop(ctx context.Context, timeout time.Duration) func() {
+	return defaultGuard.MustStop(ctx, timeout)
+}


### PR DESCRIPTION
# Description

A util that ensures a function returns after a graceful period from ctx cancelation

## Linear Ticket

< Replace_with_Linear_Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
