### PR TITLE
chore: fix dependabot group patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
       all:
         patterns:
           - "*"
+        exclude-patterns:
+          - "go.opentelemetry.io/otel*"
+          - "go.opentelemetry.io/otel/sdk"
+          - "go.opentelemetry.io/collector*"
+          - "github.com/open-telemetry/o*-collector-contrib/*"
+          - "go.opentelemetry.io/contrib/instrumentation/*"
+          - "github.com/aws/aws-sdk-go"
+          - "google.golang.org/api"
+          - "cloud.google.com/go/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
# Description

the `all` group incorrectly [contained otel deps](https://github.com/rudderlabs/rudder-go-kit/pull/590), to prevent this from happening, we need to exclude the patterns included in other groups.


## Linear Ticket

< Linear_Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
