### PR TITLE
fix: expose both loop-back and docker internal ip

### DIFF
--- a/testhelper/docker/resource/internal/ports.go
+++ b/testhelper/docker/resource/internal/ports.go
@@ -4,7 +4,10 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 )
 
-const BindHostIP = "0.0.0.0"
+const (
+	BindHostIP       = "127.0.0.1"
+	BindInternalHost = "host.docker.internal"
+)
 
 // IPv4PortBindings returns the port bindings for the given exposed ports forcing ipv4 address.
 func IPv4PortBindings(exposedPorts []string) map[docker.Port][]docker.PortBinding {
@@ -14,6 +17,10 @@ func IPv4PortBindings(exposedPorts []string) map[docker.Port][]docker.PortBindin
 		portBindings[docker.Port(exposedPort)+"/tcp"] = []docker.PortBinding{
 			{
 				HostIP:   BindHostIP,
+				HostPort: "0",
+			},
+			{
+				HostIP:   BindInternalHost,
 				HostPort: "0",
 			},
 		}


### PR DESCRIPTION
# Description

Expose both loop-back and docker internal ip

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
