### PR TITLE
fix: scylla test fails with no connections were made when creating the session

### DIFF
--- a/testhelper/docker/resource/scylla/scylla.go
+++ b/testhelper/docker/resource/scylla/scylla.go
@@ -90,6 +90,7 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource
 	if c.keyspace != "" {
 		cluster := gocql.NewCluster(url)
 		cluster.Consistency = gocql.Quorum
+		cluster.DisableInitialHostLookup = true
 		session, err := cluster.CreateSession()
 		if err != nil {
 			return nil, err

--- a/testhelper/docker/resource/scylla/scylla_test.go
+++ b/testhelper/docker/resource/scylla/scylla_test.go
@@ -18,6 +18,7 @@ func TestScylla(t *testing.T) {
 
 	cluster := gocql.NewCluster(scyllaContainer.URL)
 	cluster.Consistency = gocql.Quorum
+	cluster.DisableInitialHostLookup = true
 	session, err := cluster.CreateSession()
 	require.NoError(t, err)
 	require.NotNil(t, session)


### PR DESCRIPTION
# Description

https://github.com/apache/cassandra-gocql-driver/issues/1020#issuecomment-362494859

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
