### PR TITLE
test: scylla no ipv6

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,10 @@ jobs:
           - kafkaclient
           - testhelper
     steps:
+      - name: Disable IPv6
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/testhelper/docker/resource/scylla/config.go
+++ b/testhelper/docker/resource/scylla/config.go
@@ -1,5 +1,7 @@
 package scylla
 
+import "github.com/ory/dockertest/v3/docker"
+
 type Option func(*config)
 
 func WithTag(tag string) Option {
@@ -14,7 +16,14 @@ func WithKeyspace(keyspace string) Option {
 	}
 }
 
+func WithDockerNetwork(network *docker.Network) Option {
+	return func(c *config) {
+		c.network = network
+	}
+}
+
 type config struct {
 	tag      string
 	keyspace string
+	network  *docker.Network
 }

--- a/testhelper/docker/resource/scylla/scylla.go
+++ b/testhelper/docker/resource/scylla/scylla.go
@@ -21,9 +21,7 @@ type Resource struct {
 }
 
 func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource, error) {
-	c := &config{
-		tag: "5.4.9",
-	}
+	c := &config{tag: "6.1"}
 	for _, opt := range opts {
 		opt(c)
 	}
@@ -47,7 +45,6 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource
 	container, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository:   "scylladb/scylla",
 		Tag:          c.tag,
-		Env:          []string{},
 		ExposedPorts: []string{"9042/tcp"},
 		PortBindings: internal.IPv4PortBindings([]string{"9042"}),
 		Cmd:          []string{"--smp 1"},
@@ -115,7 +112,10 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource
 			return nil, err
 		}
 		defer session.Close()
-		err = session.Query(fmt.Sprintf("CREATE KEYSPACE IF NOT EXISTS %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };", c.keyspace)).Exec()
+		err = session.Query(fmt.Sprintf(
+			"CREATE KEYSPACE IF NOT EXISTS %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
+			c.keyspace,
+		)).Exec()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

Have Scylla integration test run without IPv6.

## Linear Ticket

< [Linear_Link](https://linear.app/rudderstack/issue/PIPE-1564/%5Bgo-kit%5D-have-scylla-integration-test-run-without-ipv6) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
