### PR TITLE
chore: update go and linter version

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -49,7 +49,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.57.1
+          version: v1.61.0
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LDFLAGS?=-s -w
 TESTFILE=_testok
 
 # go tools versions
-GOLANGCI=github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.1
+GOLANGCI=github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 gofumpt=mvdan.cc/gofumpt@latest
 govulncheck=golang.org/x/vuln/cmd/govulncheck@latest
 goimports=golang.org/x/tools/cmd/goimports@latest

--- a/filemanager/digitaloceanmanager.go
+++ b/filemanager/digitaloceanmanager.go
@@ -102,7 +102,7 @@ func (manager *digitalOceanManager) Upload(ctx context.Context, file *os.File, p
 	output, err := DOmanager.UploadWithContext(ctx, uploadInput)
 	if err != nil {
 		if awsError, ok := err.(awserr.Error); ok && awsError.Code() == "MissingRegion" {
-			err = fmt.Errorf(fmt.Sprintf(`Bucket '%s' not found.`, manager.Config.Bucket))
+			err = fmt.Errorf(`Bucket '%s' not found.`, manager.Config.Bucket)
 		}
 		return UploadedFile{}, err
 	}

--- a/filemanager/digitaloceanmanager.go
+++ b/filemanager/digitaloceanmanager.go
@@ -102,7 +102,7 @@ func (manager *digitalOceanManager) Upload(ctx context.Context, file *os.File, p
 	output, err := DOmanager.UploadWithContext(ctx, uploadInput)
 	if err != nil {
 		if awsError, ok := err.(awserr.Error); ok && awsError.Code() == "MissingRegion" {
-			err = fmt.Errorf(`Bucket '%s' not found.`, manager.Config.Bucket)
+			err = fmt.Errorf("bucket %q not found", manager.Config.Bucket)
 		}
 		return UploadedFile{}, err
 	}

--- a/filemanager/s3manager.go
+++ b/filemanager/s3manager.go
@@ -126,7 +126,7 @@ func (m *S3Manager) Upload(ctx context.Context, file *os.File, prefixes ...strin
 	output, err := s3manager.UploadWithContext(ctx, uploadInput)
 	if err != nil {
 		if codeErr, ok := err.(codeError); ok && codeErr.Code() == "MissingRegion" {
-			err = fmt.Errorf(fmt.Sprintf(`Bucket '%s' not found.`, m.config.Bucket))
+			err = fmt.Errorf(`Bucket '%s' not found.`, m.config.Bucket)
 		}
 		return UploadedFile{}, err
 	}

--- a/filemanager/s3manager.go
+++ b/filemanager/s3manager.go
@@ -126,7 +126,7 @@ func (m *S3Manager) Upload(ctx context.Context, file *os.File, prefixes ...strin
 	output, err := s3manager.UploadWithContext(ctx, uploadInput)
 	if err != nil {
 		if codeErr, ok := err.(codeError); ok && codeErr.Code() == "MissingRegion" {
-			err = fmt.Errorf(`Bucket '%s' not found.`, m.config.Bucket)
+			err = fmt.Errorf("bucket %q not found", m.config.Bucket)
 		}
 		return UploadedFile{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-go-kit
 
-go 1.22.7
+go 1.23.1
 
 replace github.com/gocql/gocql => github.com/scylladb/gocql v1.14.2
 

--- a/testhelper/docker/resource/mysql/mysql.go
+++ b/testhelper/docker/resource/mysql/mysql.go
@@ -76,7 +76,7 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...func(*Config)) (*R
 			return err
 		}
 		if code != 0 {
-			return fmt.Errorf("mysql not ready:\n%s" + w.String())
+			return fmt.Errorf("mysql not ready:\n%s", w.String())
 		}
 		return nil
 	})

--- a/testhelper/docker/resource/postgres/postgres.go
+++ b/testhelper/docker/resource/postgres/postgres.go
@@ -116,7 +116,7 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...func(*Config)) (*R
 			return err
 		}
 		if code != 0 {
-			return fmt.Errorf("postgres not ready:\n%s" + w.String())
+			return fmt.Errorf("postgres not ready:\n%s", w.String())
 		}
 
 		// 2. create a sql.DB and verify connection


### PR DESCRIPTION
# Description

Regular update to the latest go version, also `golangci-lint` for compatibility reasons, the previous version was not compatible go1.23


## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1577/rudder-go-kit-upgrade-go-version

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
