### PR TITLE
fix: flaky test: slice comparison to ignore element order

### DIFF
--- a/stats/statsd_test.go
+++ b/stats/statsd_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -421,6 +422,10 @@ func TestStatsdRegisterCollector(t *testing.T) {
 			if len(received) != len(expected) {
 				return false
 			}
+
+			sort.Strings(received)
+			sort.Strings(expected)
+
 			return reflect.DeepEqual(received, expected)
 		}, 10*time.Second, time.Millisecond)
 	}


### PR DESCRIPTION
# Description

Fixes flaky test that got introduced here https://github.com/rudderlabs/rudder-go-kit/pull/648

## Linear Ticket

https://linear.app/rudderstack/issue/PRI-48/database-sql-stats


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
