### PR TITLE
chore: update pulsar endpoint to use 127.0.0.1

### DIFF
--- a/testhelper/docker/resource/pulsar/pulsar.go
+++ b/testhelper/docker/resource/pulsar/pulsar.go
@@ -48,8 +48,8 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource
 		}
 	})
 
-	url := fmt.Sprintf("pulsar://%s:%s", container.GetBoundIP("6650/tcp"), container.GetPort("6650/tcp"))
-	adminURL := fmt.Sprintf("http://%s:%s", container.GetBoundIP("8080/tcp"), container.GetPort("8080/tcp"))
+	url := fmt.Sprintf("pulsar://127.0.0.1:%s", container.GetPort("6650/tcp"))
+	adminURL := fmt.Sprintf("http://127.0.0.1:%s", container.GetPort("8080/tcp"))
 
 	if err := pool.Retry(func() (err error) {
 		var w bytes.Buffer


### PR DESCRIPTION
# Description

Use loopback address as host address as localhost is not reachable. 

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
