### PR TITLE
feat: max procs

### DIFF
--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -10,6 +10,11 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 )
 
+const (
+	defaultMinProcs              = 1
+	defaultCPURequestsMultiplier = 1.5
+)
+
 func init() {
 	setDefault()
 }
@@ -48,8 +53,8 @@ func WithRoundQuotaFunc(roundQuotaFunc func(float64) int) Option {
 func Set(raw string, opts ...Option) {
 	conf := &conf{
 		logger:                logger.NOP,
-		minProcs:              1,
-		cpuRequestsMultiplier: 3,
+		minProcs:              defaultMinProcs,
+		cpuRequestsMultiplier: defaultCPURequestsMultiplier,
 		roundQuotaFunc:        roundQuotaCeil,
 	}
 	for _, opt := range opts {
@@ -95,8 +100,8 @@ func Set(raw string, opts ...Option) {
 func SetWithConfig(c *config.Config, opts ...Option) {
 	conf := &conf{
 		logger:                logger.NOP,
-		minProcs:              c.GetInt("MinProcs", 1),
-		cpuRequestsMultiplier: c.GetFloat64("RequestsMultiplier", 3),
+		minProcs:              c.GetInt("MinProcs", defaultMinProcs),
+		cpuRequestsMultiplier: c.GetFloat64("RequestsMultiplier", defaultCPURequestsMultiplier),
 		roundQuotaFunc:        roundQuotaCeil,
 	}
 	for _, opt := range opts {

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -1,0 +1,104 @@
+package maxprocs
+
+import (
+	"math"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+)
+
+func init() {
+	SetWithConfig(config.New(),
+		WithLogger(logger.NewLogger().Child("maxprocs")),
+	)
+}
+
+type conf struct {
+	logger                logger.Logger
+	minProcs              int
+	cpuRequestsMultiplier float64
+	roundQuotaFunc        func(float64) int
+}
+
+type Option func(*conf)
+
+func WithLogger(logger logger.Logger) Option {
+	return func(c *conf) { c.logger = logger }
+}
+
+func WithMinProcs(minProcs int) Option {
+	return func(c *conf) { c.minProcs = minProcs }
+}
+
+func WithCPURequestsMultiplier(cpuRequestsMultiplier float64) Option {
+	return func(c *conf) { c.cpuRequestsMultiplier = cpuRequestsMultiplier }
+}
+
+func WithRoundQuotaFunc(roundQuotaFunc func(float64) int) Option {
+	return func(c *conf) { c.roundQuotaFunc = roundQuotaFunc }
+}
+
+func Set(cpuRequests string, opts ...Option) {
+	conf := &conf{
+		logger:                logger.NOP,
+		minProcs:              1,
+		cpuRequestsMultiplier: 3,
+		roundQuotaFunc:        roundQuotaCeil,
+	}
+	for _, opt := range opts {
+		opt(conf)
+	}
+
+	cpuRequest := 1.0
+	if strings.HasSuffix(cpuRequests, "m") {
+		value, err := strconv.Atoi(strings.TrimSuffix(cpuRequests, "m"))
+		if err == nil {
+			cpuRequest = float64(value) / 1000
+		} else {
+			conf.logger.Warnn("unable to parse CPU requests with Atoi, using default value")
+		}
+	} else {
+		value, err := strconv.ParseFloat(cpuRequests, 64)
+		if err == nil {
+			cpuRequest = value
+		} else {
+			conf.logger.Warnn("unable to parse CPU requests with ParseFloat, using default value")
+		}
+	}
+
+	// Calculate GOMAXPROCS
+	gomaxprocs := conf.roundQuotaFunc(cpuRequest * conf.cpuRequestsMultiplier)
+
+	if gomaxprocs < conf.minProcs {
+		gomaxprocs = conf.minProcs
+	}
+
+	// Set GOMAXPROCS
+	runtime.GOMAXPROCS(gomaxprocs)
+}
+
+func SetWithConfig(c *config.Config, opts ...Option) {
+	conf := &conf{
+		logger:                logger.NOP,
+		minProcs:              c.GetInt("MaxProcs.MinProcs", 1),
+		cpuRequestsMultiplier: c.GetFloat64("MaxProcs.CPURequestsMultiplier", 3),
+		roundQuotaFunc:        roundQuotaCeil,
+	}
+	for _, opt := range opts {
+		opt(conf)
+	}
+
+	Set(c.GetString("MaxProcs.CPURequests", "1"),
+		WithLogger(conf.logger),
+		WithMinProcs(conf.minProcs),
+		WithCPURequestsMultiplier(conf.cpuRequestsMultiplier),
+		WithRoundQuotaFunc(conf.roundQuotaFunc),
+	)
+}
+
+func roundQuotaCeil(f float64) int {
+	return int(math.Ceil(f))
+}

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -78,6 +78,9 @@ func Set(cpuRequests string, opts ...Option) {
 
 	// Set GOMAXPROCS
 	runtime.GOMAXPROCS(gomaxprocs)
+
+	// Log new GOMAXPROCS
+	conf.logger.Infon("GOMAXPROCS has been configured", logger.NewIntField("GOMAXPROCS", int64(runtime.GOMAXPROCS(0))))
 }
 
 func SetWithConfig(c *config.Config, opts ...Option) {

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -11,7 +11,11 @@ import (
 )
 
 func init() {
-	SetWithConfig(config.New(),
+	setDefault()
+}
+
+func setDefault() {
+	SetWithConfig(config.New(config.WithEnvPrefix("MAXPROCS")),
 		WithLogger(logger.NewLogger().Child("maxprocs")),
 	)
 }
@@ -91,15 +95,15 @@ func Set(raw string, opts ...Option) {
 func SetWithConfig(c *config.Config, opts ...Option) {
 	conf := &conf{
 		logger:                logger.NOP,
-		minProcs:              c.GetInt("MaxProcs.MinProcs", 1),
-		cpuRequestsMultiplier: c.GetFloat64("MaxProcs.CPURequestsMultiplier", 3),
+		minProcs:              c.GetInt("MinProcs", 1),
+		cpuRequestsMultiplier: c.GetFloat64("RequestsMultiplier", 3),
 		roundQuotaFunc:        roundQuotaCeil,
 	}
 	for _, opt := range opts {
 		opt(conf)
 	}
 
-	Set(c.GetString("MaxProcs.CPURequests", "1"),
+	Set(c.GetString("Requests", "1"),
 		WithLogger(conf.logger),
 		WithMinProcs(conf.minProcs),
 		WithCPURequestsMultiplier(conf.cpuRequestsMultiplier),

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -18,22 +18,22 @@ func TestSet_Default(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)  // Capture original value
 	defer runtime.GOMAXPROCS(before) // Restore after test
 
-	mockLog := requireLoggerInfo(t, 2)
-	maxprocs.Set("500m", maxprocs.WithLogger(mockLog))
-	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 500m * 3 = 1.5 → ceil = 2
+	mockLog := requireLoggerInfo(t, 1.1, 1, 3, 4)
+	maxprocs.Set("1100m", maxprocs.WithLogger(mockLog))
+	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1100m * 3 = 3.3 → ceil = 4
 }
 
 func TestSetWithConfig_Default(t *testing.T) {
 	cfg := config.New()
-	cfg.Set("MaxProcs.CPURequests", "500m")
+	cfg.Set("MaxProcs.CPURequests", "1100m")
 
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 2)
+	mockLog := requireLoggerInfo(t, 1.1, 1, 3, 4)
 	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
 
-	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 500m * 3 = 1.5 → ceil = 2
+	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1100m * 3 = 3.3 → ceil = 4
 }
 
 func TestSet_WithInvalidCPURequest_Invalid1(t *testing.T) {
@@ -43,7 +43,13 @@ func TestSet_WithInvalidCPURequest_Invalid1(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockLog := mock_logger.NewMockLogger(ctrl)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
-	mockLog.EXPECT().Infon("GOMAXPROCS has been configured", logger.NewIntField("GOMAXPROCS", 3)).Times(1)
+	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
+		logger.NewFloatField("cpuRequests", 1),
+		logger.NewFloatField("multiplier", 3),
+		logger.NewIntField("minProcs", 1),
+		logger.NewIntField("result", 3),
+		logger.NewIntField("GOMAXPROCS", 3),
+	).Times(1)
 
 	maxprocs.Set("invalid", maxprocs.WithLogger(mockLog))
 
@@ -60,7 +66,13 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid1(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockLog := mock_logger.NewMockLogger(ctrl)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
-	mockLog.EXPECT().Infon("GOMAXPROCS has been configured", logger.NewIntField("GOMAXPROCS", 3)).Times(1)
+	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
+		logger.NewFloatField("cpuRequests", 1),
+		logger.NewFloatField("multiplier", 3),
+		logger.NewIntField("minProcs", 1),
+		logger.NewIntField("result", 3),
+		logger.NewIntField("GOMAXPROCS", 3),
+	).Times(1)
 
 	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
 
@@ -74,7 +86,13 @@ func TestSet_WithInvalidCPURequest_Invalid2(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockLog := mock_logger.NewMockLogger(ctrl)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
-	mockLog.EXPECT().Infon("GOMAXPROCS has been configured", logger.NewIntField("GOMAXPROCS", 3)).Times(1)
+	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
+		logger.NewFloatField("cpuRequests", 1),
+		logger.NewFloatField("multiplier", 3),
+		logger.NewIntField("minProcs", 1),
+		logger.NewIntField("result", 3),
+		logger.NewIntField("GOMAXPROCS", 3),
+	).Times(1)
 
 	maxprocs.Set("invalid_m", maxprocs.WithLogger(mockLog))
 
@@ -91,7 +109,13 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid2(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockLog := mock_logger.NewMockLogger(ctrl)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
-	mockLog.EXPECT().Infon("GOMAXPROCS has been configured", logger.NewIntField("GOMAXPROCS", 3)).Times(1)
+	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
+		logger.NewFloatField("cpuRequests", 1),
+		logger.NewFloatField("multiplier", 3),
+		logger.NewIntField("minProcs", 1),
+		logger.NewIntField("result", 3),
+		logger.NewIntField("GOMAXPROCS", 3),
+	).Times(1)
 
 	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
 
@@ -102,7 +126,7 @@ func TestSet_WithMinProcs(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 5)
+	mockLog := requireLoggerInfo(t, 0.1, 5, 3, 5)
 	maxprocs.Set("100m",
 		maxprocs.WithMinProcs(5),
 		maxprocs.WithLogger(mockLog),
@@ -119,7 +143,7 @@ func TestSetWithConfig_WithMinProcs(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 5)
+	mockLog := requireLoggerInfo(t, 0.1, 5, 3, 5)
 	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
 
 	require.Equal(t, 5, runtime.GOMAXPROCS(0)) // MinProcs overrides calculated value
@@ -129,7 +153,7 @@ func TestSet_WithMultiplier(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 2)
+	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 2)
 	maxprocs.Set("300m",
 		maxprocs.WithCPURequestsMultiplier(4),
 		maxprocs.WithLogger(mockLog),
@@ -146,7 +170,7 @@ func TestSetWithConfig_WithMultiplier(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 2)
+	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 2)
 	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 300m * 4 = 1.2 → ceil = 2
@@ -158,7 +182,7 @@ func TestSet_CustomRoundQuotaFunc(t *testing.T) {
 
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
-	mockLog := requireLoggerInfo(t, 4)
+	mockLog := requireLoggerInfo(t, 1.5, 1, 3, 4)
 	maxprocs.Set("1500m",
 		maxprocs.WithRoundQuotaFunc(roundFloor),
 		maxprocs.WithLogger(mockLog),
@@ -176,7 +200,7 @@ func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
 
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
-	mockLog := requireLoggerInfo(t, 4)
+	mockLog := requireLoggerInfo(t, 1.5, 1, 3, 4)
 	maxprocs.SetWithConfig(cfg,
 		maxprocs.WithRoundQuotaFunc(roundFloor),
 		maxprocs.WithLogger(mockLog),
@@ -185,9 +209,20 @@ func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
 	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1500m * 3 = 4.5 → floor = 4
 }
 
-func requireLoggerInfo(t testing.TB, required int64) logger.Logger {
+func requireLoggerInfo(t testing.TB,
+	cpuRequests float64,
+	minProcs int64,
+	multiplier float64,
+	required int64,
+) logger.Logger {
 	ctrl := gomock.NewController(t)
 	mockLog := mock_logger.NewMockLogger(ctrl)
-	mockLog.EXPECT().Infon("GOMAXPROCS has been configured", logger.NewIntField("GOMAXPROCS", required)).Times(1)
+	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
+		logger.NewFloatField("cpuRequests", cpuRequests),
+		logger.NewFloatField("multiplier", multiplier),
+		logger.NewIntField("minProcs", minProcs),
+		logger.NewIntField("result", required),
+		logger.NewIntField("GOMAXPROCS", required),
+	).Times(1)
 	return mockLog
 }

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -1,0 +1,165 @@
+package maxprocs_test
+
+import (
+	"math"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger/mock_logger"
+	"github.com/rudderlabs/rudder-go-kit/maxprocs"
+)
+
+func TestSet_Default(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)  // Capture original value
+	defer runtime.GOMAXPROCS(before) // Restore after test
+
+	maxprocs.Set("500m")
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 500m * 3 = 1.5 → ceil = 2
+}
+
+func TestSetWithConfig_Default(t *testing.T) {
+	cfg := config.New()
+	cfg.Set("MaxProcs.CPURequests", "500m")
+
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	maxprocs.SetWithConfig(cfg)
+
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 500m * 3 = 1.5 → ceil = 2
+}
+
+func TestSet_WithInvalidCPURequest_Invalid1(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	ctrl := gomock.NewController(t)
+	mockLog := mock_logger.NewMockLogger(ctrl)
+	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
+
+	maxprocs.Set("invalid", maxprocs.WithLogger(mockLog))
+
+	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
+}
+
+func TestSetWithConfig_WithInvalidCPURequest_Invalid1(t *testing.T) {
+	cfg := config.New()
+	cfg.Set("MaxProcs.CPURequests", "invalid")
+
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	ctrl := gomock.NewController(t)
+	mockLog := mock_logger.NewMockLogger(ctrl)
+	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
+
+	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
+
+	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
+}
+
+func TestSet_WithInvalidCPURequest_Invalid2(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	ctrl := gomock.NewController(t)
+	mockLog := mock_logger.NewMockLogger(ctrl)
+	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
+
+	maxprocs.Set("invalid_m", maxprocs.WithLogger(mockLog))
+
+	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
+}
+
+func TestSetWithConfig_WithInvalidCPURequest_Invalid2(t *testing.T) {
+	cfg := config.New()
+	cfg.Set("MaxProcs.CPURequests", "invalid_m")
+
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	ctrl := gomock.NewController(t)
+	mockLog := mock_logger.NewMockLogger(ctrl)
+	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
+
+	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
+
+	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
+}
+
+func TestSet_WithMinProcs(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	maxprocs.Set("100m", maxprocs.WithMinProcs(5))
+
+	require.Equal(t, 5, runtime.GOMAXPROCS(0)) // MinProcs overrides calculated value
+}
+
+func TestSetWithConfig_WithMinProcs(t *testing.T) {
+	cfg := config.New()
+	cfg.Set("MaxProcs.CPURequests", "100m")
+	cfg.Set("MaxProcs.MinProcs", 5)
+
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	maxprocs.SetWithConfig(cfg)
+
+	require.Equal(t, 5, runtime.GOMAXPROCS(0)) // MinProcs overrides calculated value
+}
+
+func TestSet_WithMultiplier(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	maxprocs.Set("300m", maxprocs.WithCPURequestsMultiplier(4))
+
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 300m * 4 = 1.2 → ceil = 2
+}
+
+func TestSetWithConfig_WithMultiplier(t *testing.T) {
+	cfg := config.New()
+	cfg.Set("MaxProcs.CPURequests", "300m")
+	cfg.Set("MaxProcs.CPURequestsMultiplier", 4)
+
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	maxprocs.SetWithConfig(cfg)
+
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 300m * 4 = 1.2 → ceil = 2
+}
+
+func TestSet_CustomRoundQuotaFunc(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	roundFloor := func(f float64) int {
+		return int(math.Floor(f))
+	}
+
+	maxprocs.Set("1500m", maxprocs.WithRoundQuotaFunc(roundFloor))
+
+	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1500m * 3 = 4.5 → floor = 4
+}
+
+func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
+	cfg := config.New()
+	cfg.Set("MaxProcs.CPURequests", "1500m")
+
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	roundFloor := func(f float64) int {
+		return int(math.Floor(f))
+	}
+
+	maxprocs.SetWithConfig(cfg, maxprocs.WithRoundQuotaFunc(roundFloor))
+
+	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1500m * 3 = 4.5 → floor = 4
+}

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -17,9 +17,9 @@ func TestSet_Default(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)  // Capture original value
 	defer runtime.GOMAXPROCS(before) // Restore after test
 
-	mockLog := requireLoggerInfo(t, 1.1, 1, 3, 4)
+	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 2)
 	Set("1100m", WithLogger(mockLog))
-	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1100m * 3 = 3.3 → ceil = 4
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1100m * 1.5 = 1.65 → ceil = 2
 }
 
 func TestSetWithConfig_Default(t *testing.T) {
@@ -29,10 +29,10 @@ func TestSetWithConfig_Default(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 1.1, 1, 3, 4)
+	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 2)
 	SetWithConfig(cfg, WithLogger(mockLog))
 
-	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1100m * 3 = 3.3 → ceil = 4
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1100m * 1.5 = 1.65 → ceil = 2
 }
 
 func TestSet_WithInvalidCPURequest_Invalid1(t *testing.T) {
@@ -44,15 +44,15 @@ func TestSet_WithInvalidCPURequest_Invalid1(t *testing.T) {
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
 	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
 		logger.NewFloatField("cpuRequests", 1),
-		logger.NewFloatField("multiplier", 3),
+		logger.NewFloatField("multiplier", 1.5),
 		logger.NewIntField("minProcs", 1),
-		logger.NewIntField("result", 3),
-		logger.NewIntField("GOMAXPROCS", 3),
+		logger.NewIntField("result", 2),
+		logger.NewIntField("GOMAXPROCS", 2),
 	).Times(1)
 
 	Set("invalid", WithLogger(mockLog))
 
-	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Defaults to 1 * 1.5 → ceil = 2
 }
 
 func TestSetWithConfig_WithInvalidCPURequest_Invalid1(t *testing.T) {
@@ -67,15 +67,15 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid1(t *testing.T) {
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
 	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
 		logger.NewFloatField("cpuRequests", 1),
-		logger.NewFloatField("multiplier", 3),
+		logger.NewFloatField("multiplier", 1.5),
 		logger.NewIntField("minProcs", 1),
-		logger.NewIntField("result", 3),
-		logger.NewIntField("GOMAXPROCS", 3),
+		logger.NewIntField("result", 2),
+		logger.NewIntField("GOMAXPROCS", 2),
 	).Times(1)
 
 	SetWithConfig(cfg, WithLogger(mockLog))
 
-	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Defaults to 1 * 1.5 → ceil = 2
 }
 
 func TestSet_WithInvalidCPURequest_Invalid2(t *testing.T) {
@@ -87,15 +87,15 @@ func TestSet_WithInvalidCPURequest_Invalid2(t *testing.T) {
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
 	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
 		logger.NewFloatField("cpuRequests", 1),
-		logger.NewFloatField("multiplier", 3),
+		logger.NewFloatField("multiplier", 1.5),
 		logger.NewIntField("minProcs", 1),
-		logger.NewIntField("result", 3),
-		logger.NewIntField("GOMAXPROCS", 3),
+		logger.NewIntField("result", 2),
+		logger.NewIntField("GOMAXPROCS", 2),
 	).Times(1)
 
 	Set("invalid_m", WithLogger(mockLog))
 
-	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Defaults to 1 * 1.5 → ceil = 2
 }
 
 func TestSetWithConfig_WithInvalidCPURequest_Invalid2(t *testing.T) {
@@ -110,22 +110,22 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid2(t *testing.T) {
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
 	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
 		logger.NewFloatField("cpuRequests", 1),
-		logger.NewFloatField("multiplier", 3),
+		logger.NewFloatField("multiplier", 1.5),
 		logger.NewIntField("minProcs", 1),
-		logger.NewIntField("result", 3),
-		logger.NewIntField("GOMAXPROCS", 3),
+		logger.NewIntField("result", 2),
+		logger.NewIntField("GOMAXPROCS", 2),
 	).Times(1)
 
 	SetWithConfig(cfg, WithLogger(mockLog))
 
-	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Defaults to 1 * 1.5 → ceil = 2
 }
 
 func TestSet_WithMinProcs(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 0.1, 5, 3, 5)
+	mockLog := requireLoggerInfo(t, 0.1, 5, 1.5, 5)
 	Set("100m",
 		WithMinProcs(5),
 		WithLogger(mockLog),
@@ -142,7 +142,7 @@ func TestSetWithConfig_WithMinProcs(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 0.1, 5, 3, 5)
+	mockLog := requireLoggerInfo(t, 0.1, 5, 1.5, 5)
 	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 5, runtime.GOMAXPROCS(0)) // MinProcs overrides calculated value
@@ -181,13 +181,13 @@ func TestSet_CustomRoundQuotaFunc(t *testing.T) {
 
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
-	mockLog := requireLoggerInfo(t, 1.5, 1, 3, 4)
+	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 2)
 	Set("1500m",
 		WithRoundQuotaFunc(roundFloor),
 		WithLogger(mockLog),
 	)
 
-	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1500m * 3 = 4.5 → floor = 4
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1500m * 1.5 = 2.25 → floor = 2
 }
 
 func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
@@ -199,13 +199,13 @@ func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
 
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
-	mockLog := requireLoggerInfo(t, 1.5, 1, 3, 4)
+	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 2)
 	SetWithConfig(cfg,
 		WithRoundQuotaFunc(roundFloor),
 		WithLogger(mockLog),
 	)
 
-	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1500m * 3 = 4.5 → floor = 4
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1500m * 1.5 = 2.25 → floor = 2
 }
 
 func TestEnvironmentVariables(t *testing.T) {
@@ -215,7 +215,7 @@ func TestEnvironmentVariables(t *testing.T) {
 	t.Setenv("MAXPROCS_REQUESTS", "1100m")
 
 	setDefault()
-	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1100m * 3 = 3.3 → ceil = 4
+	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1100m * 1.5 = 1.65 → ceil = 2
 
 	t.Setenv("MAXPROCS_MIN_PROCS", "5")
 	setDefault()

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -1,4 +1,4 @@
-package maxprocs_test
+package maxprocs
 
 import (
 	"math"
@@ -11,7 +11,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/logger/mock_logger"
-	"github.com/rudderlabs/rudder-go-kit/maxprocs"
 )
 
 func TestSet_Default(t *testing.T) {
@@ -19,19 +18,19 @@ func TestSet_Default(t *testing.T) {
 	defer runtime.GOMAXPROCS(before) // Restore after test
 
 	mockLog := requireLoggerInfo(t, 1.1, 1, 3, 4)
-	maxprocs.Set("1100m", maxprocs.WithLogger(mockLog))
+	Set("1100m", WithLogger(mockLog))
 	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1100m * 3 = 3.3 → ceil = 4
 }
 
 func TestSetWithConfig_Default(t *testing.T) {
 	cfg := config.New()
-	cfg.Set("MaxProcs.CPURequests", "1100m")
+	cfg.Set("Requests", "1100m")
 
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 1.1, 1, 3, 4)
-	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
+	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1100m * 3 = 3.3 → ceil = 4
 }
@@ -51,14 +50,14 @@ func TestSet_WithInvalidCPURequest_Invalid1(t *testing.T) {
 		logger.NewIntField("GOMAXPROCS", 3),
 	).Times(1)
 
-	maxprocs.Set("invalid", maxprocs.WithLogger(mockLog))
+	Set("invalid", WithLogger(mockLog))
 
 	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
 }
 
 func TestSetWithConfig_WithInvalidCPURequest_Invalid1(t *testing.T) {
 	cfg := config.New()
-	cfg.Set("MaxProcs.CPURequests", "invalid")
+	cfg.Set("Requests", "invalid")
 
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
@@ -74,7 +73,7 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid1(t *testing.T) {
 		logger.NewIntField("GOMAXPROCS", 3),
 	).Times(1)
 
-	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
+	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
 }
@@ -94,14 +93,14 @@ func TestSet_WithInvalidCPURequest_Invalid2(t *testing.T) {
 		logger.NewIntField("GOMAXPROCS", 3),
 	).Times(1)
 
-	maxprocs.Set("invalid_m", maxprocs.WithLogger(mockLog))
+	Set("invalid_m", WithLogger(mockLog))
 
 	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
 }
 
 func TestSetWithConfig_WithInvalidCPURequest_Invalid2(t *testing.T) {
 	cfg := config.New()
-	cfg.Set("MaxProcs.CPURequests", "invalid_m")
+	cfg.Set("Requests", "invalid_m")
 
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
@@ -117,7 +116,7 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid2(t *testing.T) {
 		logger.NewIntField("GOMAXPROCS", 3),
 	).Times(1)
 
-	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
+	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Defaults to 1 * 3 → ceil = 3
 }
@@ -127,9 +126,9 @@ func TestSet_WithMinProcs(t *testing.T) {
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 0.1, 5, 3, 5)
-	maxprocs.Set("100m",
-		maxprocs.WithMinProcs(5),
-		maxprocs.WithLogger(mockLog),
+	Set("100m",
+		WithMinProcs(5),
+		WithLogger(mockLog),
 	)
 
 	require.Equal(t, 5, runtime.GOMAXPROCS(0)) // MinProcs overrides calculated value
@@ -137,14 +136,14 @@ func TestSet_WithMinProcs(t *testing.T) {
 
 func TestSetWithConfig_WithMinProcs(t *testing.T) {
 	cfg := config.New()
-	cfg.Set("MaxProcs.CPURequests", "100m")
-	cfg.Set("MaxProcs.MinProcs", 5)
+	cfg.Set("Requests", "100m")
+	cfg.Set("MinProcs", 5)
 
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 0.1, 5, 3, 5)
-	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
+	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 5, runtime.GOMAXPROCS(0)) // MinProcs overrides calculated value
 }
@@ -154,9 +153,9 @@ func TestSet_WithMultiplier(t *testing.T) {
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 2)
-	maxprocs.Set("300m",
-		maxprocs.WithCPURequestsMultiplier(4),
-		maxprocs.WithLogger(mockLog),
+	Set("300m",
+		WithCPURequestsMultiplier(4),
+		WithLogger(mockLog),
 	)
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 300m * 4 = 1.2 → ceil = 2
@@ -164,14 +163,14 @@ func TestSet_WithMultiplier(t *testing.T) {
 
 func TestSetWithConfig_WithMultiplier(t *testing.T) {
 	cfg := config.New()
-	cfg.Set("MaxProcs.CPURequests", "300m")
-	cfg.Set("MaxProcs.CPURequestsMultiplier", 4)
+	cfg.Set("Requests", "300m")
+	cfg.Set("RequestsMultiplier", 4)
 
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 2)
-	maxprocs.SetWithConfig(cfg, maxprocs.WithLogger(mockLog))
+	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 300m * 4 = 1.2 → ceil = 2
 }
@@ -183,9 +182,9 @@ func TestSet_CustomRoundQuotaFunc(t *testing.T) {
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
 	mockLog := requireLoggerInfo(t, 1.5, 1, 3, 4)
-	maxprocs.Set("1500m",
-		maxprocs.WithRoundQuotaFunc(roundFloor),
-		maxprocs.WithLogger(mockLog),
+	Set("1500m",
+		WithRoundQuotaFunc(roundFloor),
+		WithLogger(mockLog),
 	)
 
 	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1500m * 3 = 4.5 → floor = 4
@@ -193,7 +192,7 @@ func TestSet_CustomRoundQuotaFunc(t *testing.T) {
 
 func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
 	cfg := config.New()
-	cfg.Set("MaxProcs.CPURequests", "1500m")
+	cfg.Set("Requests", "1500m")
 
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
@@ -201,12 +200,30 @@ func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
 	mockLog := requireLoggerInfo(t, 1.5, 1, 3, 4)
-	maxprocs.SetWithConfig(cfg,
-		maxprocs.WithRoundQuotaFunc(roundFloor),
-		maxprocs.WithLogger(mockLog),
+	SetWithConfig(cfg,
+		WithRoundQuotaFunc(roundFloor),
+		WithLogger(mockLog),
 	)
 
 	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1500m * 3 = 4.5 → floor = 4
+}
+
+func TestEnvironmentVariables(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	t.Setenv("MAXPROCS_REQUESTS", "1100m")
+
+	setDefault()
+	require.Equal(t, 4, runtime.GOMAXPROCS(0)) // 1100m * 3 = 3.3 → ceil = 4
+
+	t.Setenv("MAXPROCS_MIN_PROCS", "5")
+	setDefault()
+	require.Equal(t, 5, runtime.GOMAXPROCS(0))
+
+	t.Setenv("MAXPROCS_REQUESTS_MULTIPLIER", "6")
+	setDefault()
+	require.Equal(t, 7, runtime.GOMAXPROCS(0))
 }
 
 func requireLoggerInfo(t testing.TB,


### PR DESCRIPTION
# Description

Given that setting K8s limits has [proven](https://home.robusta.dev/blog/stop-using-cpu-limits) to be causing performance issues, we can only set CPU requests.

**Considerations:**
* In order to contain costs we want to set CPU requests to a value that makes sense to handle normal traffic for a given namespace. 
* We should not use K8s CPU limits to avoid throttling.
* We should not waste unused CPU if there is demand for it.
* The services should be able to use more than the requested CPUs (if there is some available) to better handle spikes of traffic.
* Setting `GOMAXPROCS` to a very high number or leaving it unset will set it to a very high value (e.g. `64`) causing serious GC performance degradation.
* What we have now in `ingestion-svc` and `src-router` is that `GOMAXPROCS` = `requests.cpu`.
   * This is creating issues because the microservice will never go above `GOMAXPROCS` meaning it can hardly handle spikes of traffic.

Thus, I'm proposing a new package where we can simply do this in the operator:

```yaml
          env:
            - name: MAX_PROCS_CPU_REQUESTS
              valueFrom:
                resourceFieldRef:
                  resource: requests.cpu
```

At the moment we have this instead:

```yaml
          env:
            - name: GOMAXPROCS
              valueFrom:
                resourceFieldRef:
                  resource: requests.cpu
```

Then the package in this PR (i.e. `maxprocs`) will read the new env var and set a proper "limit" via `GOMAXPROCS` by setting it to `X` times the CPU requests (see `MaxProcs.CPURequestsMultiplier` setting).

## How to use

Simply import the package like this:

```go
import _ "github.com/rudderlabs/rudder-go-kit/maxprocs"
```

The package will read `MaxProcs.CPURequests` and set `GOMAXPROCS` to `MaxProcs.CPURequestsMultiplier` times. It will then round the value with ceiling.

**Example:** 500m * 3 = 1500m -> ceil -> GOMAXPROCS = 2 CPUs

### Configuration variables
* `MaxProcs.CPURequests` (this is set automatically by the operator)
* `MaxProcs.CPURequestsMultiplier` (this is used to multiply `requests.cpu` to get the final value for `GOMAXPROCS. it defaults to 3.)
* `MaxProcs.MinProcs` (no matter the configuration, we will never go below this value. it defaults to `1`.)

## Operator PR

https://github.com/rudderlabs/rudderstack-operator/pull/3134

## Linear Ticket

< [Linear_Link](https://linear.app/rudderstack/issue/PIPE-1852/go-kit-changes-gomaxprocs) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
