### PR TITLE
chore: throttling tagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LDFLAGS?=-s -w
 TESTFILE=_testok
 
 # go tools versions
-GOLANGCI=github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+GOLANGCI=github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 gofumpt=mvdan.cc/gofumpt@latest
 govulncheck=golang.org/x/vuln/cmd/govulncheck@latest
 goimports=golang.org/x/tools/cmd/goimports@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-go-kit
 
-go 1.23.1
+go 1.23.5
 
 replace github.com/gocql/gocql => github.com/scylladb/gocql v1.14.2
 

--- a/throttling/options.go
+++ b/throttling/options.go
@@ -36,9 +36,12 @@ func WithRedisSortedSet(rc *redis.Client) Option {
 	}
 }
 
-// WithStatsCollector allows to setup a stats collector for the limiter
+// WithStatsCollector allows to set up a stats collector for the limiter
 func WithStatsCollector(sc statsCollector) Option {
-	return func(l *Limiter) {
-		l.statsCollector = sc
-	}
+	return func(l *Limiter) { l.statsCollector = sc }
+}
+
+// WithStatsTagger allows to set up a stats tagger for the limiter
+func WithStatsTagger(st statsTagger) Option {
+	return func(l *Limiter) { l.statsTagger = st }
 }


### PR DESCRIPTION
# Description

Adding a way to customize tags in throttler.

Updating go version as well to fix a few vulnerabilities in `net/http@go1.23.1` and `crypto/x509@go1.23.1`.

See [here](https://github.com/rudderlabs/rudder-go-kit/actions/runs/13031397974/job/36351341283?pr=730).

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
