### PR TITLE
fix(stats): deadlock during stats stop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-go-kit
 
-go 1.23.5
+go 1.23.6
 
 replace github.com/gocql/gocql => github.com/scylladb/gocql v1.14.2
 

--- a/stats/statsd.go
+++ b/stats/statsd.go
@@ -155,9 +155,6 @@ func (s *statsdStats) RegisterCollector(c Collector) error {
 
 // Stop stops periodic collection of stats.
 func (s *statsdStats) Stop() {
-	s.state.clientsLock.RLock()
-	defer s.state.clientsLock.RUnlock()
-
 	if !s.config.enabled.Load() || !s.state.connEstablished {
 		return
 	}


### PR DESCRIPTION
# Description

An unecessary read lock on `clientsLock` mutex during `Stop()` could cause a deadlock in the following scenario:
- `Stop()` is called by `goroutineA` which acquires the read lock
- Stat collection `goroutineB` is requesting a new stat. In such a case a full lock is required but it is not possible, causing `goroutineB` to block.
- `goroutineA` is waiting for `goroutineB` to finish so that `Stop()` returns, but `goroutineA` is blocked.

During `Stop()` `clientsLock` is not necessary to be read-locked, since there is nothing to protect at this phase.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
