### PR TITLE
feat: include rss memory in calculated mem stats

### DIFF
--- a/mem/internal/cgroup/mem.go
+++ b/mem/internal/cgroup/mem.go
@@ -22,6 +22,14 @@ func GetMemoryUsage(basePath string) int64 {
 	return getWSSMemoryCgroup2(basePath, n)
 }
 
+// GetMemoryRSS returns cgroup (v1 or v2) rss memory
+func GetMemoryRSS(basePath string) int64 {
+	if rss := getRSSMemoryCgroup1(basePath); rss > 0 {
+		return rss
+	}
+	return getRSSMemoryCgroup2(basePath)
+}
+
 // GetMemoryLimit returns the cgroup's (v1 or v2) memory limit, or [totalMem] if there is no limit set.
 // If using cgroups v1, hierarchical memory limit is also taken into consideration if there is no limit set.
 //
@@ -89,6 +97,10 @@ func getWSSMemoryCgroup2(basePath string, used int64) int64 {
 		return 0
 	}
 	return used - inactive
+}
+
+func getRSSMemoryCgroup2(basePath string) int64 {
+	return memStatCgroup2(basePath, "anon")
 }
 
 func memStatCgroup1(basePath, key string) int64 {

--- a/mem/internal/cgroup/mem_test.go
+++ b/mem/internal/cgroup/mem_test.go
@@ -17,6 +17,7 @@ func TestCgroupMemory(t *testing.T) {
 
 		require.EqualValues(t, 25*bytesize.GB, limit, "when a limit is set, this limit should be returned")
 		require.EqualValues(t, 7873486848, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 7873486848, cgroup.GetMemoryRSS(basePath))
 	})
 
 	t.Run("cgroups v1 with self limit", func(t *testing.T) {
@@ -26,6 +27,7 @@ func TestCgroupMemory(t *testing.T) {
 
 		require.EqualValues(t, 25*bytesize.GB, limit, "when a limit is set, this limit should be returned")
 		require.EqualValues(t, 9456156572, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 9456156572, cgroup.GetMemoryRSS(basePath))
 	})
 
 	t.Run("cgroups v1 with hierarchical limit", func(t *testing.T) {
@@ -35,6 +37,7 @@ func TestCgroupMemory(t *testing.T) {
 
 		require.EqualValues(t, 25*bytesize.GB, limit, "when a hierarchical limit is set, this limit should be returned")
 		require.EqualValues(t, 7873486848, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 7873486848, cgroup.GetMemoryRSS(basePath))
 	})
 
 	t.Run("cgroups v1 no limit", func(t *testing.T) {
@@ -44,6 +47,7 @@ func TestCgroupMemory(t *testing.T) {
 
 		require.EqualValues(t, totalMem, limit, "when no limit is set, total memory should be returned")
 		require.EqualValues(t, 7873486848, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 7873486848, cgroup.GetMemoryRSS(basePath))
 	})
 
 	t.Run("cgroups v2 with limit", func(t *testing.T) {
@@ -53,6 +57,7 @@ func TestCgroupMemory(t *testing.T) {
 
 		require.EqualValues(t, 32*bytesize.GB, limit, "when a limit is set, this limit should be returned")
 		require.EqualValues(t, 26071040, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 3145728, cgroup.GetMemoryRSS(basePath))
 	})
 
 	t.Run("cgroups v2 no limit", func(t *testing.T) {
@@ -62,6 +67,7 @@ func TestCgroupMemory(t *testing.T) {
 
 		require.EqualValues(t, totalMem, limit, "when no limit is set, total memory should be returned")
 		require.EqualValues(t, 26071040, cgroup.GetMemoryUsage(basePath))
+		require.EqualValues(t, 3145728, cgroup.GetMemoryRSS(basePath))
 	})
 
 	t.Run("no cgroups info", func(t *testing.T) {

--- a/mem/internal/cgroup/testdata/cgroups_v1_mem_limit_proc_self/sys/fs/cgroup/memory/pid1/memory.stat
+++ b/mem/internal/cgroup/testdata/cgroups_v1_mem_limit_proc_self/sys/fs/cgroup/memory/pid1/memory.stat
@@ -18,7 +18,7 @@ unevictable 0
 hierarchical_memory_limit 26843545600
 hierarchical_memsw_limit 26843545600
 total_cache 1853911040
-total_rss 100
+total_rss 9456156572
 total_rss_huge 2638217216
 total_shmem 0
 total_mapped_file 0

--- a/mem/mem.go
+++ b/mem/mem.go
@@ -12,14 +12,31 @@ import (
 type Stat struct {
 	// Total memory in bytes
 	Total uint64
-	// Available memory in bytes
+	// Available memory in bytes, calculated as [Total] - [Used]
 	Available uint64
 	// Available memory in percentage
 	AvailablePercent float64
-	// Used memory in bytes
+	// Used memory in bytes. Includes [total_active_file], that is cache memory that has been identified as active by the kernel.
 	Used uint64
 	// Used memory in percentage
 	UsedPercent float64
+	// Size of RSS in bytes. Like Used, but without [total_active_file].
+	RSS uint64
+}
+
+// RSSPercent returns the percentage of RSS memory
+func (s *Stat) RSSPercent() float64 {
+	return float64(s.RSS) * 100 / float64(s.Total)
+}
+
+// AvailableIgnoreCache returns the available memory in bytes, ignoring cache memory. This is calculated as [Total] - [RSS]
+func (s *Stat) AvailableIgnoreCache() uint64 {
+	return s.Total - s.RSS
+}
+
+// AvailableIgnoreCachePercent returns the available memory in percentage, ignoring cache memory. This is calculated as [Total] - [RSS]
+func (s *Stat) AvailableIgnoreCachePercent() float64 {
+	return float64(s.AvailableIgnoreCache()) * 100 / float64(s.Total)
 }
 
 // Get current memory statistics
@@ -52,11 +69,16 @@ func (c *collector) Get() (*Stat, error) {
 		if stat.Used > stat.Total {
 			stat.Used = stat.Total
 		}
+		stat.RSS = uint64(cgroup.GetMemoryRSS(c.basePath))
+		if stat.RSS == 0 || stat.RSS > stat.Used {
+			stat.RSS = stat.Used
+		}
 		stat.Available = stat.Total - stat.Used
 	} else {
 		stat.Total = mem.Total
 		stat.Available = mem.Available
 		stat.Used = stat.Total - stat.Available
+		stat.RSS = stat.Used
 	}
 	stat.AvailablePercent = float64(stat.Available) * 100 / float64(stat.Total)
 	stat.UsedPercent = float64(stat.Used) * 100 / float64(stat.Total)


### PR DESCRIPTION
# Description

In some scenarios, it might be preferable to monitor `container_memory_rss` instead of `container_memory_working_set_bytes` due to the following issue: https://github.com/kubernetes/kubernetes/issues/43916

Now `mem.Stat` contains `RSS` memory in bytes, along with some derived methods:
- `RSSPercent` - returns the percentage of RSS memory
- `AvailableIgnoreCache` - returns the available memory in bytes, ignoring cache memory. This is calculated as [Total] - [RSS]
- `AvailableIgnoreCachePercent` - returns the available memory in percentage, ignoring cache memory. This is calculated as [Total] - [RSS]

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
