### PR TITLE
chore: add options to run image using docker credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-go-kit
 
-go 1.23.6
+go 1.23.8
 
 replace github.com/gocql/gocql => github.com/scylladb/gocql v1.14.2
 

--- a/testhelper/docker/resource/transformer/transformer.go
+++ b/testhelper/docker/resource/transformer/transformer.go
@@ -31,7 +31,6 @@ type config struct {
 	envs         []string
 	extraHosts   []string
 	network      *docker.Network
-	alwaysPull   bool
 	authConfig   docker.AuthConfiguration
 }
 

--- a/testhelper/docker/resource/transformer/transformer.go
+++ b/testhelper/docker/resource/transformer/transformer.go
@@ -110,9 +110,9 @@ func WithRepository(repository string) Option {
 	}
 }
 
-func WithAlwaysPull(alwayPull bool) Option {
+func WithAlwaysPull(alwaysPull bool) Option {
 	return func(conf *config) {
-		conf.alwaysPull = alwayPull
+		conf.alwaysPull = alwaysPull
 	}
 }
 

--- a/testhelper/docker/resource/transformer/transformer.go
+++ b/testhelper/docker/resource/transformer/transformer.go
@@ -110,9 +110,9 @@ func WithRepository(repository string) Option {
 	}
 }
 
-func WithAlwaysPull(allowPull bool) Option {
+func WithAlwaysPull(alwayPull bool) Option {
 	return func(conf *config) {
-		conf.alwaysPull = allowPull
+		conf.alwaysPull = alwayPull
 	}
 }
 

--- a/testhelper/docker/resource/transformer/transformer.go
+++ b/testhelper/docker/resource/transformer/transformer.go
@@ -31,7 +31,7 @@ type config struct {
 	envs         []string
 	extraHosts   []string
 	network      *docker.Network
-	checkpull    bool
+	alwaysPull   bool
 }
 
 func (c *config) setBackendConfigURL(url string) {
@@ -110,9 +110,9 @@ func WithRepository(repository string) Option {
 	}
 }
 
-func WithCheckPull(checkpull bool) Option {
+func WithAlwaysPull(allowPull bool) Option {
 	return func(conf *config) {
-		conf.checkpull = checkpull
+		conf.alwaysPull = allowPull
 	}
 }
 
@@ -127,7 +127,7 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource
 		envs: []string{
 			"CONFIG_BACKEND_URL=https://api.rudderstack.com",
 		},
-		checkpull: true,
+		alwaysPull: true,
 	}
 
 	for _, opt := range opts {
@@ -136,7 +136,7 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource
 
 	// The PullImage function uses only the provided AuthConfiguration and always try to pull the image from registry
 	// For usecase where we already have the image locally, we can skip the pull step
-	if conf.checkpull {
+	if conf.alwaysPull {
 		if err := pool.Client.PullImage(docker.PullImageOptions{
 			Repository: conf.repository,
 			Tag:        conf.tag,

--- a/testhelper/docker/resource/transformer/transformer_test.go
+++ b/testhelper/docker/resource/transformer/transformer_test.go
@@ -106,29 +106,29 @@ func TestSetup(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, gjson.Get(string(respData), "0.output.transformed").Bool())
 	})
-	t.Run("test image pull behavior based on checkpull flag", func(t *testing.T) {
+	t.Run("test image pull behavior based on alwaysPull flag", func(t *testing.T) {
 		tests := []struct {
 			name            string
 			tag             string
 			urlPath         string
 			repository      string
-			checkpull       bool
+			alwaysPull      bool
 			expectPullError bool
 		}{
 			{
-				name:            "checkpull=true: should return image pull error",
+				name:            "alwaysPull=true: should return image pull error",
 				tag:             "feat.salesforce.cache.support.search",
 				urlPath:         "health",
 				repository:      "rudderstack/develop-rudder-transformer",
-				checkpull:       true,
+				alwaysPull:      true,
 				expectPullError: true,
 			},
 			{
-				name:            "checkpull=false: should ignore image pull error",
+				name:            "alwaysPull=false: should ignore image pull error",
 				tag:             "feat.salesforce.cache.support.search",
 				urlPath:         "health",
 				repository:      "rudderstack/develop-rudder-transformer",
-				checkpull:       false,
+				alwaysPull:      false,
 				expectPullError: false,
 			},
 		}
@@ -138,7 +138,7 @@ func TestSetup(t *testing.T) {
 				_, err := transformer.Setup(pool, t,
 					transformer.WithRepository(tt.repository),
 					transformer.WithDockerImageTag(tt.tag),
-					transformer.WithCheckPull(tt.checkpull),
+					transformer.WithAlwaysPull(tt.alwaysPull),
 				)
 
 				require.Error(t, err)

--- a/testhelper/docker/resource/transformer/transformer_test.go
+++ b/testhelper/docker/resource/transformer/transformer_test.go
@@ -106,49 +106,4 @@ func TestSetup(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, gjson.Get(string(respData), "0.output.transformed").Bool())
 	})
-	t.Run("test image pull behavior based on alwaysPull flag", func(t *testing.T) {
-		tests := []struct {
-			name            string
-			tag             string
-			urlPath         string
-			repository      string
-			alwaysPull      bool
-			expectPullError bool
-		}{
-			{
-				name:            "alwaysPull=true: should return image pull error",
-				tag:             "feat.salesforce.cache.support.search",
-				urlPath:         "health",
-				repository:      "rudderstack/develop-rudder-transformer",
-				alwaysPull:      true,
-				expectPullError: true,
-			},
-			{
-				name:            "alwaysPull=false: should ignore image pull error",
-				tag:             "feat.salesforce.cache.support.search",
-				urlPath:         "health",
-				repository:      "rudderstack/develop-rudder-transformer",
-				alwaysPull:      false,
-				expectPullError: false,
-			},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				_, err := transformer.Setup(pool, t,
-					transformer.WithRepository(tt.repository),
-					transformer.WithDockerImageTag(tt.tag),
-					transformer.WithAlwaysPull(tt.alwaysPull),
-				)
-
-				require.Error(t, err)
-
-				if tt.expectPullError {
-					require.Contains(t, err.Error(), "failed to pull image: ")
-				} else {
-					require.NotContains(t, err.Error(), "failed to pull image: ")
-				}
-			})
-		}
-	})
 }


### PR DESCRIPTION
# Description

In order to run a private transformer docker image, we need to pass an auth credential to `setup` functions.
We added an option to pass docker auth credentials.
This is needed to run the ingestion-svc test using private docker images of the transformer

Resolves INT-2926
## Linear Ticket

https://linear.app/rudderstack/issue/INT-2926/automating-integration-tests-as-part-of-pr

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
