### PR TITLE
feat: add trie data structure for prefix string matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/rudder-go-kit
 
-go 1.23.6
+go 1.23.8
 
 replace github.com/gocql/gocql => github.com/scylladb/gocql v1.14.2
 

--- a/trie/benchmark_test.go
+++ b/trie/benchmark_test.go
@@ -25,7 +25,30 @@ BenchmarkTrie/Get/10000_items_10_chars_0.0_hit_rate-12             14371        
 BenchmarkTrie/Get/100000_items_50_chars_1.0_hit_rate-12             1318            868631 ns/op          248000 B/op       5000 allocs/op
 BenchmarkTrie/Get/100000_items_50_chars_0.5_hit_rate-12             2562            475571 ns/op          130176 B/op       3120 allocs/op
 BenchmarkTrie/Get/100000_items_50_chars_0.0_hit_rate-12            10000            108950 ns/op           12624 B/op       1260 allocs/op
+
+
+
+memory profile:
+
+Showing nodes accounting for 23638.81MB, 99.71% of 23707.34MB total
+Dropped 45 nodes (cum <= 118.54MB)
+Showing top 10 nodes out of 11
+
+	flat  flat%   sum%        cum   cum%
+
+22098.73MB 93.21% 93.21% 22098.73MB 93.21%  github.com/rudderlabs/rudder-go-kit/trie.(*Trie).Insert (inline)
+
+	1105.05MB  4.66% 97.88%  1105.05MB  4.66%  unicode/utf8.appendRuneNonASCII
+	 435.02MB  1.83% 99.71%  1540.07MB  6.50%  unicode/utf8.AppendRune (inline)
+	        0     0% 99.71%  1540.07MB  6.50%  github.com/rudderlabs/rudder-go-kit/trie.(*Trie).Get
+	        0     0% 99.71% 19397.43MB 81.82%  github.com/rudderlabs/rudder-go-kit/trie.BenchmarkTrie.func1.1
+	        0     0% 99.71%  2744.61MB 11.58%  github.com/rudderlabs/rudder-go-kit/trie.BenchmarkTrie.func2
+	        0     0% 99.71%  1540.07MB  6.50%  github.com/rudderlabs/rudder-go-kit/trie.BenchmarkTrie.func2.1
+	        0     0% 99.71%  1540.07MB  6.50%  strings.(*Builder).WriteRune
+	        0     0% 99.71% 19854.87MB 83.75%  testing.(*B).launch
+	        0     0% 99.71%  3846.46MB 16.22%  testing.(*B).run1.func1
 */
+
 func BenchmarkTrie(b *testing.B) {
 	b.Run("Insert", func(b *testing.B) {
 		testCases := []struct {

--- a/trie/benchmark_test.go
+++ b/trie/benchmark_test.go
@@ -1,0 +1,138 @@
+package trie
+
+import (
+	"fmt"
+
+	"crypto/rand"
+	mathrand "math/rand"
+	"testing"
+)
+
+/*
+goos: darwin
+goarch: arm64
+pkg: github.com/rudderlabs/rudder-go-kit/trie
+cpu: Apple M2 Pro
+BenchmarkTrie/Insert/1000_items_10_chars-12                 1449            765763 ns/op         1571211 B/op      23404 allocs/op
+BenchmarkTrie/Insert/10000_items_10_chars-12                 140           8791232 ns/op        14210344 B/op     212759 allocs/op
+BenchmarkTrie/Insert/100000_items_10_chars-12                 13          88382346 ns/op        132672852 B/op   1975541 allocs/op
+BenchmarkTrie/Insert/1000_items_50_chars-12                  248           4839381 ns/op         9587178 B/op     139020 allocs/op
+BenchmarkTrie/Insert/10000_items_50_chars-12                  25          46529992 ns/op        94296304 B/op    1368181 allocs/op
+BenchmarkTrie/Insert/100000_items_50_chars-12                  3         468312653 ns/op        933582800 B/op  13526962 allocs/op
+
+BenchmarkTrie/Get/10000_items_10_chars_1.0_hit_rate-12              5466            211260 ns/op           46720 B/op       2710 allocs/op
+BenchmarkTrie/Get/10000_items_10_chars_0.5_hit_rate-12              7622            147444 ns/op           29072 B/op       1955 allocs/op
+BenchmarkTrie/Get/10000_items_10_chars_0.0_hit_rate-12             15283             78597 ns/op           11816 B/op       1217 allocs/op
+BenchmarkTrie/Get/100000_items_50_chars_1.0_hit_rate-12             1315            865524 ns/op          248000 B/op       5000 allocs/op
+BenchmarkTrie/Get/100000_items_50_chars_0.5_hit_rate-12             2481            472676 ns/op          130312 B/op       3126 allocs/op
+BenchmarkTrie/Get/100000_items_50_chars_0.0_hit_rate-12            10333            123480 ns/op           12568 B/op       1262 allocs/op
+*/
+func BenchmarkTrie(b *testing.B) {
+
+	b.Run("Insert", func(b *testing.B) {
+		testCases := []struct {
+			numItems  int
+			keyLength int
+		}{
+			{1000, 10},
+			{10000, 10},
+			{100000, 10}, // Potentially large memory usage
+			{1000, 50},
+			{10000, 50},
+			{100000, 50}, // Potentially large memory usage
+		}
+
+		for _, tc := range testCases {
+			name := fmt.Sprintf("%d_items_%d_chars", tc.numItems, tc.keyLength)
+			dataToInsert := generateData(tc.numItems, tc.keyLength)
+
+			b.Run(name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					t := NewTrie()
+
+					for _, key := range dataToInsert {
+						t.Insert(key)
+					}
+				}
+			})
+		}
+	})
+
+	b.Run("Get", func(b *testing.B) {
+		searchTestCases := []struct {
+			numItems  int
+			keyLength int
+			hitRatio  float64 // Percentage of searches for existing keys
+		}{
+			{10000, 10, 1.0}, // All hits
+			{10000, 10, 0.5}, // 50% hits, 50% misses
+			{10000, 10, 0.0}, // All misses
+			{100000, 50, 1.0},
+			{100000, 50, 0.5},
+			{100000, 50, 0.0},
+		}
+
+		for _, tc := range searchTestCases {
+			// 1. Pre-populate a trie
+			t := NewTrie()
+			data := generateData(tc.numItems, tc.keyLength)
+			searchKeys := make([]string, 0, tc.numItems)
+			for _, key := range data {
+				t.Insert(key)
+				searchKeys = append(searchKeys, key)
+			}
+
+			// 2. Generate search keys based on hitRatio
+			numSearchOps := 1000
+			keysToSearch := make([]string, numSearchOps)
+			numHits := int(float64(numSearchOps) * tc.hitRatio)
+			var err error
+			for i := 0; i < numSearchOps; i++ {
+				if i < numHits {
+					// Pick a random existing key
+					keysToSearch[i] = searchKeys[mathrand.Intn(len(searchKeys))]
+				} else {
+					// Generate a random key likely not in the trie
+					keysToSearch[i], err = generateRandomString(tc.keyLength)
+					if err != nil {
+						panic(err)
+					}
+				}
+			}
+
+			// 3. Run the benchmark
+			name := fmt.Sprintf("%d_items_%d_chars_%.1f_hit_rate", tc.numItems, tc.keyLength, tc.hitRatio)
+			b.Run(name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					for _, key := range keysToSearch {
+						_, _ = t.Get(key)
+					}
+				}
+			})
+		}
+	})
+}
+
+func generateRandomString(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func generateData(numItems, keyLength int) []string {
+	data := make([]string, numItems)
+	for i := 0; i < numItems; i++ {
+		key, err := generateRandomString(keyLength)
+		if err != nil {
+			panic(err)
+		}
+		data[i] = key
+	}
+	return data
+}

--- a/trie/benchmark_test.go
+++ b/trie/benchmark_test.go
@@ -128,7 +128,7 @@ func BenchmarkTrie(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					for _, key := range keysToSearch {
-						_, _ = t.Get(key)
+						_, _ = t.GetMatchedPrefixWord(key)
 					}
 				}
 			})

--- a/trie/benchmark_test.go
+++ b/trie/benchmark_test.go
@@ -12,19 +12,19 @@ goos: darwin
 goarch: arm64
 pkg: github.com/rudderlabs/rudder-go-kit/trie
 cpu: Apple M2 Pro
-BenchmarkTrie/Insert/1000_items_10_chars-12                 1449            765763 ns/op         1571211 B/op      23404 allocs/op
-BenchmarkTrie/Insert/10000_items_10_chars-12                 140           8791232 ns/op        14210344 B/op     212759 allocs/op
-BenchmarkTrie/Insert/100000_items_10_chars-12                 13          88382346 ns/op        132672852 B/op   1975541 allocs/op
-BenchmarkTrie/Insert/1000_items_50_chars-12                  248           4839381 ns/op         9587178 B/op     139020 allocs/op
-BenchmarkTrie/Insert/10000_items_50_chars-12                  25          46529992 ns/op        94296304 B/op    1368181 allocs/op
-BenchmarkTrie/Insert/100000_items_50_chars-12                  3         468312653 ns/op        933582800 B/op  13526962 allocs/op
+BenchmarkTrie/Insert/1000_items_10_chars-12                 1440            917506 ns/op         1563102 B/op      23287 allocs/op
+BenchmarkTrie/Insert/10000_items_10_chars-12                 122           9826675 ns/op        14141638 B/op     212074 allocs/op
+BenchmarkTrie/Insert/100000_items_10_chars-12                 13          91967837 ns/op        132748437 B/op   1976261 allocs/op
+BenchmarkTrie/Insert/1000_items_50_chars-12                  247           5039432 ns/op         9564105 B/op     138687 allocs/op
+BenchmarkTrie/Insert/10000_items_50_chars-12                  22          47210977 ns/op        94315532 B/op    1368365 allocs/op
+BenchmarkTrie/Insert/100000_items_50_chars-12                  2         509287521 ns/op        933780416 B/op  13530038 allocs/op
 
-BenchmarkTrie/Get/10000_items_10_chars_1.0_hit_rate-12              5466            211260 ns/op           46720 B/op       2710 allocs/op
-BenchmarkTrie/Get/10000_items_10_chars_0.5_hit_rate-12              7622            147444 ns/op           29072 B/op       1955 allocs/op
-BenchmarkTrie/Get/10000_items_10_chars_0.0_hit_rate-12             15283             78597 ns/op           11816 B/op       1217 allocs/op
-BenchmarkTrie/Get/100000_items_50_chars_1.0_hit_rate-12             1315            865524 ns/op          248000 B/op       5000 allocs/op
-BenchmarkTrie/Get/100000_items_50_chars_0.5_hit_rate-12             2481            472676 ns/op          130312 B/op       3126 allocs/op
-BenchmarkTrie/Get/100000_items_50_chars_0.0_hit_rate-12            10333            123480 ns/op           12568 B/op       1262 allocs/op
+BenchmarkTrie/Get/10000_items_10_chars_1.0_hit_rate-12              5078            220148 ns/op           46912 B/op       2716 allocs/op
+BenchmarkTrie/Get/10000_items_10_chars_0.5_hit_rate-12              6721            164567 ns/op           29368 B/op       1960 allocs/op
+BenchmarkTrie/Get/10000_items_10_chars_0.0_hit_rate-12             14371             86925 ns/op           11736 B/op       1200 allocs/op
+BenchmarkTrie/Get/100000_items_50_chars_1.0_hit_rate-12             1318            868631 ns/op          248000 B/op       5000 allocs/op
+BenchmarkTrie/Get/100000_items_50_chars_0.5_hit_rate-12             2562            475571 ns/op          130176 B/op       3120 allocs/op
+BenchmarkTrie/Get/100000_items_50_chars_0.0_hit_rate-12            10000            108950 ns/op           12624 B/op       1260 allocs/op
 */
 func BenchmarkTrie(b *testing.B) {
 	b.Run("Insert", func(b *testing.B) {
@@ -75,11 +75,9 @@ func BenchmarkTrie(b *testing.B) {
 		for _, tc := range searchTestCases {
 			// 1. Pre-populate a trie
 			t := NewTrie()
-			data := generateData(tc.numItems, tc.keyLength)
-			searchKeys := make([]string, 0, tc.numItems)
-			for _, key := range data {
+			dataToInsert := generateData(tc.numItems, tc.keyLength)
+			for _, key := range dataToInsert {
 				t.Insert(key)
-				searchKeys = append(searchKeys, key)
 			}
 
 			// 2. Generate search keys based on hitRatio
@@ -90,7 +88,7 @@ func BenchmarkTrie(b *testing.B) {
 			for i := 0; i < numSearchOps; i++ {
 				if i < numHits {
 					// Pick a random existing key
-					keysToSearch[i] = searchKeys[mathrand.Intn(len(searchKeys))]
+					keysToSearch[i] = dataToInsert[mathrand.Intn(len(dataToInsert))]
 				} else {
 					// Generate a random key likely not in the trie
 					keysToSearch[i], err = generateRandomString(tc.keyLength)

--- a/trie/benchmark_test.go
+++ b/trie/benchmark_test.go
@@ -27,7 +27,6 @@ BenchmarkTrie/Get/100000_items_50_chars_0.5_hit_rate-12             2481        
 BenchmarkTrie/Get/100000_items_50_chars_0.0_hit_rate-12            10333            123480 ns/op           12568 B/op       1262 allocs/op
 */
 func BenchmarkTrie(b *testing.B) {
-
 	b.Run("Insert", func(b *testing.B) {
 		testCases := []struct {
 			numItems  int

--- a/trie/benchmark_test.go
+++ b/trie/benchmark_test.go
@@ -1,9 +1,8 @@
 package trie
 
 import (
-	"fmt"
-
 	"crypto/rand"
+	"fmt"
 	mathrand "math/rand"
 	"testing"
 )

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -65,9 +65,8 @@ func (t *Trie) Insert(word string) {
 //   - string: The shortest matching prefix word found. Returns an empty string
 //     if no matching prefix word is found.
 //
-// Note: If the input string is empty, the function returns (false, "") immediately,
-// regardless of whether an empty string was inserted via Insert(""). The root node's
-// isEndOfWord flag is not considered in this specific scenario.
+// Note: If the input string is empty, the function always returns (false, ""),
+// regardless of whether an empty string was inserted via Insert("").
 func (t *Trie) Get(input string) (bool, string) {
 	node := t.root
 	var matched strings.Builder
@@ -78,7 +77,10 @@ func (t *Trie) Get(input string) (bool, string) {
 			break
 		}
 
-		matched.WriteRune(r)
+		_, err := matched.WriteRune(r)
+		if err != nil {
+			panic(err)
+		}
 		if node.isEndOfWord {
 			// Found a prefix that is a word.
 			return true, matched.String()

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -2,6 +2,13 @@ package trie
 
 import "strings"
 
+// Trie is a prefix tree data structure.
+// It stores words in a way that allows for efficient prefix-based searching.
+
+// This implementation is not concurrent safe.
+// It should not be used from multiple goroutines concurrently without additional synchronization.
+
+// Node represents a single node within the trie.
 type Node struct {
 	children    map[rune]*Node
 	isEndOfWord bool
@@ -11,7 +18,7 @@ type Trie struct {
 	root *Node
 }
 
-// NewTrie creates a new Trie
+// NewTrie creates and initializes a new, empty Trie.
 func NewTrie() *Trie {
 	return &Trie{
 		root: &Node{
@@ -21,8 +28,16 @@ func NewTrie() *Trie {
 	}
 }
 
-// Insert adds a word to the trie
+// Insert adds a word to the trie. If the word already exists,
+// its end marker might be updated, but the structure remains the same.
+// Intermediate nodes are created as needed.
+//
+// Note: If the input string is empty, the function will not insert anything.
 func (t *Trie) Insert(word string) {
+	if word == "" {
+		return
+	}
+
 	node := t.root
 	for _, r := range word {
 		child := node.children[r]
@@ -38,20 +53,39 @@ func (t *Trie) Insert(word string) {
 	node.isEndOfWord = true
 }
 
-// Get checks if any word in the trie matches the start of the input string
+// Get checks if any prefix of the input string is registered as a complete word
+// in the trie.
+//
+// It traverses the trie character by character based on the input string.
+// If it encounters a node marked as the end of a word during this traversal,
+// it means a prefix of the input is a complete word in the trie.
+//
+// Return values:
+//   - bool: true if a prefix matching a complete word is found, false otherwise.
+//   - string: The shortest matching prefix word found. Returns an empty string
+//     if no matching prefix word is found.
+//
+// Note: If the input string is empty, the function returns (false, "") immediately,
+// regardless of whether an empty string was inserted via Insert(""). The root node's
+// isEndOfWord flag is not considered in this specific scenario.
 func (t *Trie) Get(input string) (bool, string) {
 	node := t.root
 	var matched strings.Builder
 	for _, r := range input {
 		node = node.children[r]
 		if node == nil {
+			// No further matching prefix found in the trie.
 			break
 		}
 
 		matched.WriteRune(r)
 		if node.isEndOfWord {
+			// Found a prefix that is a word.
 			return true, matched.String()
 		}
 	}
+
+	// Reached the end of the input or a dead end in the trie
+	// without finding a node marked as the end of a word.
 	return false, ""
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -1,0 +1,57 @@
+package trie
+
+import "strings"
+
+type Node struct {
+	children    map[rune]*Node
+	isEndOfWord bool
+}
+
+type Trie struct {
+	root *Node
+}
+
+// NewTrie creates a new Trie
+func NewTrie() *Trie {
+	return &Trie{
+		root: &Node{
+			children:    make(map[rune]*Node),
+			isEndOfWord: false,
+		},
+	}
+}
+
+// Insert adds a word to the trie
+func (t *Trie) Insert(word string) {
+	node := t.root
+	for _, r := range word {
+		child := node.children[r]
+		if child == nil {
+			child = &Node{
+				children:    make(map[rune]*Node),
+				isEndOfWord: false,
+			}
+			node.children[r] = child
+		}
+		node = child
+	}
+	node.isEndOfWord = true
+}
+
+// Get checks if any word in the trie matches the start of the input string
+func (t *Trie) Get(input string) (bool, string) {
+	node := t.root
+	var matched strings.Builder
+	for _, r := range input {
+		node = node.children[r]
+		if node == nil {
+			break
+		}
+
+		matched.WriteRune(r)
+		if node.isEndOfWord {
+			return true, matched.String()
+		}
+	}
+	return false, ""
+}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -4,6 +4,7 @@ import "strings"
 
 // Trie is a prefix tree data structure.
 // It stores words in a way that allows for efficient prefix-based searching.
+// This implementation is case sensitive; "word" and "Word" are treated as different entries.
 
 // This implementation is not concurrent safe.
 // It should not be used from multiple goroutines concurrently without additional synchronization.

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -1,0 +1,54 @@
+package trie
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrie(t *testing.T) {
+	t.Run("Insert and Get", func(t *testing.T) {
+		trie := NewTrie()
+		trie.Insert("hello")
+
+		found, matched := trie.Get("hello world")
+		require.True(t, found)
+		require.Equal(t, "hello", matched)
+
+		found, matched = trie.Get("world")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+
+		// non-ascii
+		trie.Insert("你好")
+		trie.Insert("世界 ABCD")
+
+		found, matched = trie.Get("你好世界")
+		require.True(t, found)
+		require.Equal(t, "你好", matched)
+
+		found, matched = trie.Get("你")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+
+		found, matched = trie.Get("世界 ABCD")
+		require.True(t, found)
+		require.Equal(t, "世界 ABCD", matched)
+
+		// number and special characters
+		trie.Insert("1234567890")
+		trie.Insert("!@#$%^&*()")
+
+		found, matched = trie.Get("1234567890")
+		require.True(t, found)
+		require.Equal(t, "1234567890", matched)
+
+		found, matched = trie.Get("!@#$%^&*()1234567890")
+		require.True(t, found)
+		require.Equal(t, "!@#$%^&*()", matched)
+
+		found, matched = trie.Get("1234567890!@#$%^&*()")
+		require.True(t, found)
+		require.Equal(t, "1234567890", matched)
+	})
+}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -75,10 +75,8 @@ func TestTrie(t *testing.T) {
 
 	t.Run("empty string", func(t *testing.T) {
 		trie := NewTrie()
-		trie.Insert("")
+		trie.Insert("") // word is not added to the trie as it's empty after trimming
 
-		// Test querying with an empty string. Even if "" was inserted,
-		// it shouldn't be considered a valid match.
 		found, matched := trie.GetMatchedPrefixWord("")
 		require.False(t, found)
 		require.Equal(t, "", matched)

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTrie(t *testing.T) {
-	t.Run("Insert and Get", func(t *testing.T) {
+	t.Run("basic functionality", func(t *testing.T) {
 		trie := NewTrie()
 		trie.Insert("hello")
 
@@ -18,22 +18,6 @@ func TestTrie(t *testing.T) {
 		found, matched = trie.Get("world")
 		require.False(t, found)
 		require.Equal(t, "", matched)
-
-		// non-ascii
-		trie.Insert("你好")
-		trie.Insert("世界 ABCD")
-
-		found, matched = trie.Get("你好世界")
-		require.True(t, found)
-		require.Equal(t, "你好", matched)
-
-		found, matched = trie.Get("你")
-		require.False(t, found)
-		require.Equal(t, "", matched)
-
-		found, matched = trie.Get("世界 ABCD")
-		require.True(t, found)
-		require.Equal(t, "世界 ABCD", matched)
 
 		// number and special characters
 		trie.Insert("1234567890")
@@ -50,5 +34,221 @@ func TestTrie(t *testing.T) {
 		found, matched = trie.Get("1234567890!@#$%^&*()")
 		require.True(t, found)
 		require.Equal(t, "1234567890", matched)
+	})
+
+	t.Run("non-ascii", func(t *testing.T) {
+		trie := NewTrie()
+
+		trie.Insert("你好")
+		trie.Insert("世界 ABCD")
+
+		found, matched := trie.Get("你好世界")
+		require.True(t, found)
+		require.Equal(t, "你好", matched)
+
+		found, matched = trie.Get("你")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+
+		found, matched = trie.Get("世界 ABCD")
+		require.True(t, found)
+		require.Equal(t, "世界 ABCD", matched)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		trie := NewTrie()
+		trie.Insert("")
+
+		// Test querying with an empty string. Even if "" was inserted,
+		// it shouldn't be considered a valid match.
+		found, matched := trie.Get("")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+	})
+
+	t.Run("spaces and tabs", func(t *testing.T) {
+		trie := NewTrie()
+		trie.Insert(" ")
+
+		found, matched := trie.Get(" abc")
+		require.True(t, found)
+		require.Equal(t, " ", matched)
+
+		found, matched = trie.Get("  ")
+		require.True(t, found)
+		require.Equal(t, " ", matched)
+
+		found, matched = trie.Get("abc")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+
+		// tab
+		trie.Insert("	")
+
+		found, matched = trie.Get("	 abc")
+		require.True(t, found)
+		require.Equal(t, "	", matched)
+
+		found, matched = trie.Get("	")
+		require.True(t, found)
+		require.Equal(t, "	", matched)
+
+		found, matched = trie.Get("abc")
+		require.False(t, found)
+	})
+
+	t.Run("multiple word insertions with common prefixes", func(t *testing.T) {
+		trie := NewTrie()
+		trie.Insert("ab")
+		trie.Insert("abc")
+
+		found, matched := trie.Get("abcd")
+		require.True(t, found)
+		require.Equal(t, "ab", matched)
+
+		found, matched = trie.Get("ab")
+		require.True(t, found)
+		require.Equal(t, "ab", matched)
+
+		trie = NewTrie()
+		trie.Insert("a")
+		trie.Insert("ab")
+		trie.Insert("abc")
+
+		found, matched = trie.Get("abcd")
+		require.True(t, found)
+		require.Equal(t, "a", matched)
+
+		found, matched = trie.Get("abd")
+		require.True(t, found)
+		require.Equal(t, "a", matched)
+
+		found, matched = trie.Get("ad")
+		require.True(t, found)
+		require.Equal(t, "a", matched)
+
+		found, matched = trie.Get("b")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+	})
+
+	t.Run("case sensitivity", func(t *testing.T) {
+		trie := NewTrie()
+		trie.Insert("Hello")
+
+		found, matched := trie.Get("Hello")
+		require.True(t, found)
+		require.Equal(t, "Hello", matched)
+
+		found, matched = trie.Get("hello")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+
+		trie.Insert("hello")
+		found, matched = trie.Get("hello")
+		require.True(t, found)
+		require.Equal(t, "hello", matched)
+	})
+
+	t.Run("edge cases - unusual unicode", func(t *testing.T) {
+		trie := NewTrie()
+		trie.Insert("😀")
+		trie.Insert("👩‍👧‍👦") // Family: woman, girl, boy ZWJ sequence
+
+		found, matched := trie.Get("😀 Smiling Face With Open Mouth")
+		require.True(t, found)
+		require.Equal(t, "😀", matched)
+
+		found, matched = trie.Get("👩‍👧‍👦 Family")
+		require.True(t, found)
+		require.Equal(t, "👩‍👧‍👦", matched)
+
+		found, matched = trie.Get("👩‍👧‍") // Part of the ZWJ sequence
+		require.False(t, found)
+		require.Equal(t, "", matched)
+	})
+
+	t.Run("edge cases - long string", func(t *testing.T) {
+		trie := NewTrie()
+		longString := "This is a very long string that we are inserting into the trie to test its behavior with lengthy inputs, potentially exceeding buffer sizes or hitting performance limits if not implemented efficiently."
+		trie.Insert(longString)
+
+		found, matched := trie.Get(longString + " And some extra text.")
+		require.True(t, found)
+		require.Equal(t, longString, matched)
+
+		found, matched = trie.Get(longString[:len(longString)-1]) // Slightly shorter
+		require.False(t, found)
+		require.Equal(t, "", matched)
+	})
+
+	t.Run("empty trie", func(t *testing.T) {
+		trie := NewTrie()
+		found, matched := trie.Get("anything")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+
+		found, matched = trie.Get("")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+	})
+
+	t.Run("multiple inserts of the same word", func(t *testing.T) {
+		trie := NewTrie()
+		trie.Insert("test")
+		trie.Insert("test")
+		trie.Insert("test")
+
+		found, matched := trie.Get("testing")
+		require.True(t, found)
+		require.Equal(t, "test", matched)
+
+		found, matched = trie.Get("tes")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+	})
+
+	t.Run("deeper trie structure", func(t *testing.T) {
+		trie := NewTrie()
+		trie.Insert("a")
+		trie.Insert("ab")
+		trie.Insert("abc")
+		trie.Insert("abcd")
+		trie.Insert("b")
+		trie.Insert("bc")
+		trie.Insert("bcd")
+		trie.Insert("abd") // Branching off 'ab'
+		trie.Insert("cdef")
+		trie.Insert("cdefg")
+
+		// Test deepest matches
+		found, matched := trie.Get("abcde")
+		require.True(t, found)
+		require.Equal(t, "a", matched)
+
+		found, matched = trie.Get("bcde")
+		require.True(t, found)
+		require.Equal(t, "b", matched)
+
+		found, matched = trie.Get("abde")
+		require.True(t, found)
+		require.Equal(t, "a", matched)
+
+		found, matched = trie.Get("cdef123456")
+		require.True(t, found)
+		require.Equal(t, "cdef", matched)
+
+		found, matched = trie.Get("cdefg")
+		require.True(t, found)
+		require.Equal(t, "cdef", matched)
+
+		// Test non-matches
+		found, matched = trie.Get("c")
+		require.False(t, found)
+		require.Equal(t, "", matched)
+
+		found, matched = trie.Get("cde1")
+		require.False(t, found)
+		require.Equal(t, "", matched)
 	})
 }

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -95,6 +95,7 @@ func TestTrie(t *testing.T) {
 
 		found, matched = trie.Get("abc")
 		require.False(t, found)
+		require.Equal(t, "", matched)
 	})
 
 	t.Run("multiple word insertions with common prefixes", func(t *testing.T) {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -11,38 +11,44 @@ func TestTrie(t *testing.T) {
 		trie := NewTrie()
 		trie.Insert("hello")
 
-		found, matched := trie.Get("hello world")
+		found, matched := trie.GetMatchedPrefixWord("hello world")
 		require.True(t, found)
 		require.Equal(t, "hello", matched)
+		require.True(t, trie.HasMatchedPrefixWords("hello world"))
 
-		found, matched = trie.Get("world")
+		found, matched = trie.GetMatchedPrefixWord("world")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("world"))
 
 		// number and special characters
 		trie.Insert("1234567890")
 		trie.Insert("!@#$%^&*()")
 
-		found, matched = trie.Get("1234567890")
+		found, matched = trie.GetMatchedPrefixWord("1234567890")
 		require.True(t, found)
 		require.Equal(t, "1234567890", matched)
+		require.True(t, trie.HasMatchedPrefixWords("1234567890"))
 
-		found, matched = trie.Get("!@#$%^&*()1234567890")
+		found, matched = trie.GetMatchedPrefixWord("!@#$%^&*()1234567890")
 		require.True(t, found)
 		require.Equal(t, "!@#$%^&*()", matched)
+		require.True(t, trie.HasMatchedPrefixWords("!@#$%^&*()1234567890"))
 
-		found, matched = trie.Get("1234567890!@#$%^&*()")
+		found, matched = trie.GetMatchedPrefixWord("1234567890!@#$%^&*()")
 		require.True(t, found)
 		require.Equal(t, "1234567890", matched)
+		require.True(t, trie.HasMatchedPrefixWords("1234567890!@#$%^&*()"))
 	})
 
 	t.Run("only complete words can match", func(t *testing.T) {
 		trie := NewTrie()
 		trie.Insert("Message in a bottle")
 
-		found, matched := trie.Get("bot")
+		found, matched := trie.GetMatchedPrefixWord("bot")
 		require.False(t, found)
 		require.Empty(t, matched)
+		require.False(t, trie.HasMatchedPrefixWords("bot"))
 	})
 
 	t.Run("non-ascii", func(t *testing.T) {
@@ -51,17 +57,20 @@ func TestTrie(t *testing.T) {
 		trie.Insert("你好")
 		trie.Insert("世界 ABCD")
 
-		found, matched := trie.Get("你好世界")
+		found, matched := trie.GetMatchedPrefixWord("你好世界")
 		require.True(t, found)
 		require.Equal(t, "你好", matched)
+		require.True(t, trie.HasMatchedPrefixWords("你好世界"))
 
-		found, matched = trie.Get("你")
+		found, matched = trie.GetMatchedPrefixWord("你")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("你"))
 
-		found, matched = trie.Get("世界 ABCD")
+		found, matched = trie.GetMatchedPrefixWord("世界 ABCD")
 		require.True(t, found)
 		require.Equal(t, "世界 ABCD", matched)
+		require.True(t, trie.HasMatchedPrefixWords("世界 ABCD"))
 	})
 
 	t.Run("empty string", func(t *testing.T) {
@@ -70,41 +79,60 @@ func TestTrie(t *testing.T) {
 
 		// Test querying with an empty string. Even if "" was inserted,
 		// it shouldn't be considered a valid match.
-		found, matched := trie.Get("")
+		found, matched := trie.GetMatchedPrefixWord("")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords(""))
 	})
 
 	t.Run("spaces and tabs", func(t *testing.T) {
 		trie := NewTrie()
-		trie.Insert(" ")
+		trie.Insert(" ") // word is not added to the trie as it's empty after trimming
+		trie.Insert("    abc   ")
 
-		found, matched := trie.Get(" abc")
-		require.True(t, found)
-		require.Equal(t, " ", matched)
-
-		found, matched = trie.Get("  ")
-		require.True(t, found)
-		require.Equal(t, " ", matched)
-
-		found, matched = trie.Get("abc")
+		found, matched := trie.GetMatchedPrefixWord(" abc")
 		require.False(t, found)
-		require.Equal(t, "", matched)
+		require.Empty(t, matched)
+		require.False(t, trie.HasMatchedPrefixWords(" abc"))
+
+		found, matched = trie.GetMatchedPrefixWord("abc   ")
+		require.True(t, found)
+		require.Equal(t, "abc", matched)
+		require.True(t, trie.HasMatchedPrefixWords("abc   "))
+
+		found, matched = trie.GetMatchedPrefixWord("  ")
+		require.False(t, found)
+		require.Empty(t, matched)
+		require.False(t, trie.HasMatchedPrefixWords("  "))
+
+		found, matched = trie.GetMatchedPrefixWord("abc")
+		require.True(t, found)
+		require.Equal(t, "abc", matched)
+		require.True(t, trie.HasMatchedPrefixWords("abc"))
 
 		// tab
-		trie.Insert("	")
+		trie.Insert("	") // word is not added to the trie as it's empty after trimming
+		trie.Insert("	 xyz	")
 
-		found, matched = trie.Get("	 abc")
-		require.True(t, found)
-		require.Equal(t, "	", matched)
-
-		found, matched = trie.Get("	")
-		require.True(t, found)
-		require.Equal(t, "	", matched)
-
-		found, matched = trie.Get("abc")
+		found, matched = trie.GetMatchedPrefixWord("	 xyz")
 		require.False(t, found)
-		require.Equal(t, "", matched)
+		require.Empty(t, matched)
+		require.False(t, trie.HasMatchedPrefixWords("	 xyz"))
+
+		found, matched = trie.GetMatchedPrefixWord("xyz		")
+		require.True(t, found)
+		require.Equal(t, "xyz", matched)
+		require.True(t, trie.HasMatchedPrefixWords("xyz		"))
+
+		found, matched = trie.GetMatchedPrefixWord("	")
+		require.False(t, found)
+		require.Empty(t, matched)
+		require.False(t, trie.HasMatchedPrefixWords("	"))
+
+		found, matched = trie.GetMatchedPrefixWord("xyz")
+		require.True(t, found)
+		require.Equal(t, "xyz", matched)
+		require.True(t, trie.HasMatchedPrefixWords("xyz"))
 	})
 
 	t.Run("multiple word insertions with common prefixes", func(t *testing.T) {
@@ -112,52 +140,61 @@ func TestTrie(t *testing.T) {
 		trie.Insert("ab")
 		trie.Insert("abc")
 
-		found, matched := trie.Get("abcd")
+		found, matched := trie.GetMatchedPrefixWord("abcd")
 		require.True(t, found)
 		require.Equal(t, "ab", matched)
+		require.True(t, trie.HasMatchedPrefixWords("abcd"))
 
-		found, matched = trie.Get("ab")
+		found, matched = trie.GetMatchedPrefixWord("ab")
 		require.True(t, found)
 		require.Equal(t, "ab", matched)
+		require.True(t, trie.HasMatchedPrefixWords("ab"))
 
 		trie = NewTrie()
 		trie.Insert("a")
 		trie.Insert("ab")
 		trie.Insert("abc")
 
-		found, matched = trie.Get("abcd")
+		found, matched = trie.GetMatchedPrefixWord("abcd")
 		require.True(t, found)
 		require.Equal(t, "a", matched)
+		require.True(t, trie.HasMatchedPrefixWords("abcd"))
 
-		found, matched = trie.Get("abd")
+		found, matched = trie.GetMatchedPrefixWord("abd")
 		require.True(t, found)
 		require.Equal(t, "a", matched)
+		require.True(t, trie.HasMatchedPrefixWords("abd"))
 
-		found, matched = trie.Get("ad")
+		found, matched = trie.GetMatchedPrefixWord("ad")
 		require.True(t, found)
 		require.Equal(t, "a", matched)
+		require.True(t, trie.HasMatchedPrefixWords("ad"))
 
-		found, matched = trie.Get("b")
+		found, matched = trie.GetMatchedPrefixWord("b")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("b"))
 	})
 
 	t.Run("case sensitivity", func(t *testing.T) {
 		trie := NewTrie()
 		trie.Insert("Hello")
 
-		found, matched := trie.Get("Hello")
+		found, matched := trie.GetMatchedPrefixWord("Hello")
 		require.True(t, found)
 		require.Equal(t, "Hello", matched)
+		require.True(t, trie.HasMatchedPrefixWords("Hello"))
 
-		found, matched = trie.Get("hello")
+		found, matched = trie.GetMatchedPrefixWord("hello")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("hello"))
 
 		trie.Insert("hello")
-		found, matched = trie.Get("hello")
+		found, matched = trie.GetMatchedPrefixWord("hello")
 		require.True(t, found)
 		require.Equal(t, "hello", matched)
+		require.True(t, trie.HasMatchedPrefixWords("hello"))
 	})
 
 	t.Run("edge cases - unusual unicode", func(t *testing.T) {
@@ -165,17 +202,20 @@ func TestTrie(t *testing.T) {
 		trie.Insert("😀")
 		trie.Insert("👩‍👧‍👦") // Family: woman, girl, boy ZWJ sequence
 
-		found, matched := trie.Get("😀 Smiling Face With Open Mouth")
+		found, matched := trie.GetMatchedPrefixWord("😀 Smiling Face With Open Mouth")
 		require.True(t, found)
 		require.Equal(t, "😀", matched)
+		require.True(t, trie.HasMatchedPrefixWords("😀 Smiling Face With Open Mouth"))
 
-		found, matched = trie.Get("👩‍👧‍👦 Family")
+		found, matched = trie.GetMatchedPrefixWord("👩‍👧‍👦 Family")
 		require.True(t, found)
 		require.Equal(t, "👩‍👧‍👦", matched)
+		require.True(t, trie.HasMatchedPrefixWords("👩‍👧‍👦 Family"))
 
-		found, matched = trie.Get("👩‍👧‍") // Part of the ZWJ sequence
+		found, matched = trie.GetMatchedPrefixWord("👩‍👧‍") // Part of the ZWJ sequence
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("👩‍👧‍"))
 	})
 
 	t.Run("edge cases - long string", func(t *testing.T) {
@@ -183,24 +223,28 @@ func TestTrie(t *testing.T) {
 		longString := "This is a very long string that we are inserting into the trie to test its behavior with lengthy inputs, potentially exceeding buffer sizes or hitting performance limits if not implemented efficiently."
 		trie.Insert(longString)
 
-		found, matched := trie.Get(longString + " And some extra text.")
+		found, matched := trie.GetMatchedPrefixWord(longString + " And some extra text.")
 		require.True(t, found)
 		require.Equal(t, longString, matched)
+		require.True(t, trie.HasMatchedPrefixWords(longString+" And some extra text."))
 
-		found, matched = trie.Get(longString[:len(longString)-1]) // Slightly shorter
+		found, matched = trie.GetMatchedPrefixWord(longString[:len(longString)-1]) // Slightly shorter
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords(longString[:len(longString)-1]))
 	})
 
 	t.Run("empty trie", func(t *testing.T) {
 		trie := NewTrie()
-		found, matched := trie.Get("anything")
+		found, matched := trie.GetMatchedPrefixWord("anything")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("anything"))
 
-		found, matched = trie.Get("")
+		found, matched = trie.GetMatchedPrefixWord("")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("anything"))
 	})
 
 	t.Run("multiple inserts of the same word", func(t *testing.T) {
@@ -209,13 +253,15 @@ func TestTrie(t *testing.T) {
 		trie.Insert("test")
 		trie.Insert("test")
 
-		found, matched := trie.Get("testing")
+		found, matched := trie.GetMatchedPrefixWord("testing")
 		require.True(t, found)
 		require.Equal(t, "test", matched)
+		require.True(t, trie.HasMatchedPrefixWords("testing"))
 
-		found, matched = trie.Get("tes")
+		found, matched = trie.GetMatchedPrefixWord("tes")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("tes"))
 	})
 
 	t.Run("deeper trie structure", func(t *testing.T) {
@@ -232,33 +278,40 @@ func TestTrie(t *testing.T) {
 		trie.Insert("cdefg")
 
 		// Test deepest matches
-		found, matched := trie.Get("abcde")
+		found, matched := trie.GetMatchedPrefixWord("abcde")
 		require.True(t, found)
 		require.Equal(t, "a", matched)
+		require.True(t, trie.HasMatchedPrefixWords("abcde"))
 
-		found, matched = trie.Get("bcde")
+		found, matched = trie.GetMatchedPrefixWord("bcde")
 		require.True(t, found)
 		require.Equal(t, "b", matched)
+		require.True(t, trie.HasMatchedPrefixWords("bcde"))
 
-		found, matched = trie.Get("abde")
+		found, matched = trie.GetMatchedPrefixWord("abde")
 		require.True(t, found)
 		require.Equal(t, "a", matched)
+		require.True(t, trie.HasMatchedPrefixWords("abde"))
 
-		found, matched = trie.Get("cdef123456")
+		found, matched = trie.GetMatchedPrefixWord("cdef123456")
 		require.True(t, found)
 		require.Equal(t, "cdef", matched)
+		require.True(t, trie.HasMatchedPrefixWords("cdef123456"))
 
-		found, matched = trie.Get("cdefg")
+		found, matched = trie.GetMatchedPrefixWord("cdefg")
 		require.True(t, found)
 		require.Equal(t, "cdef", matched)
+		require.True(t, trie.HasMatchedPrefixWords("cdefg"))
 
 		// Test non-matches
-		found, matched = trie.Get("c")
+		found, matched = trie.GetMatchedPrefixWord("c")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("c"))
 
-		found, matched = trie.Get("cde1")
+		found, matched = trie.GetMatchedPrefixWord("cde1")
 		require.False(t, found)
 		require.Equal(t, "", matched)
+		require.False(t, trie.HasMatchedPrefixWords("cde1"))
 	})
 }

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -36,6 +36,15 @@ func TestTrie(t *testing.T) {
 		require.Equal(t, "1234567890", matched)
 	})
 
+	t.Run("only complete words can match", func(t *testing.T) {
+		trie := NewTrie()
+		trie.Insert("Message in a bottle")
+
+		found, matched := trie.Get("bot")
+		require.False(t, found)
+		require.Empty(t, matched)
+	})
+
 	t.Run("non-ascii", func(t *testing.T) {
 		trie := NewTrie()
 


### PR DESCRIPTION
# Description

This PR introduces a trie data structure to support efficient prefix string matching operations. It also updates the Go version to v1.23.8 to address some security vulnerabilities

### Methods
- NewTrie() - Creates a new empty trie
- Insert(word string) - Adds a word to the trie
- GetMatchedPrefixWord(input string) - Returns (bool, string) indicating if a prefix match was found and the matching prefix
- HasMatchedPrefixWords(input string) - Returns bool indicating if any prefix matches a complete word

### Notes
- Not concurrent safe, requires external synchronization for concurrent access
- Trims words before inserting them to the trie.


## Linear Ticket

[Resolves OBS-823](https://linear.app/rudderstack/issue/OBS-823/add-trie-implementation-in-go-kit
)
## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
