### PR TITLE
chore: expose kafka producer batch bytes configuration property

### DIFF
--- a/kafkaclient/producer.go
+++ b/kafkaclient/producer.go
@@ -28,6 +28,7 @@ type ProducerConfig struct {
 	ReadTimeout,
 	BatchTimeout time.Duration
 	BatchSize   int
+	BatchBytes  int64
 	Compression Compression
 	Logger      Logger
 	ErrorLogger Logger
@@ -92,6 +93,7 @@ func (c *Client) NewProducer(producerConf ProducerConfig) (p *Producer, err erro
 			ReadTimeout:            producerConf.ReadTimeout,
 			BatchTimeout:           producerConf.BatchTimeout,
 			BatchSize:              producerConf.BatchSize,
+			BatchBytes:             producerConf.BatchBytes,
 			MaxAttempts:            3,
 			RequiredAcks:           kafka.RequireAll,
 			AllowAutoTopicCreation: true,


### PR DESCRIPTION
# Description

It can be beneficial to be able to override the default value if 1MB

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
