### PR TITLE
feat: introduce netutil package

### DIFF
--- a/netutil/ip_ranges.go
+++ b/netutil/ip_ranges.go
@@ -50,10 +50,9 @@ func (c CIDRs) Contains(ip net.IP) bool {
 }
 
 func (c CIDRs) String() string {
-	var sb strings.Builder
-	for _, ipnet := range c {
-		sb.WriteString(ipnet.String())
-		sb.WriteString(",")
+	cidrs := make([]string, len(c))
+	for i, ipnet := range c {
+		cidrs[i] = ipnet.String()
 	}
-	return sb.String()
+	return strings.Join(cidrs, ",")
 }

--- a/netutil/ip_ranges.go
+++ b/netutil/ip_ranges.go
@@ -1,0 +1,50 @@
+package netutil
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// Default private IP ranges in CIDR notation
+const DefaultPrivateIPRanges = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8,169.254.0.0/16,fc00::/7,fe80::/10"
+
+// PrivateCidrRanges holds the default private IP ranges
+var PrivateCidrRanges CidrRanges
+
+func init() {
+	// Initialize PrivateCidrRanges with default private IP ranges
+	var err error
+	PrivateCidrRanges, err = NewCidrRanges(
+		strings.Split(DefaultPrivateIPRanges, ","),
+	)
+	if err != nil {
+		panic(fmt.Errorf("failed to initialize private CIDR ranges: %w", err))
+	}
+}
+
+// CidrRanges holds a list of parsed CIDR ranges
+type CidrRanges []*net.IPNet
+
+// NewCidrRanges initializes CidrRanges from a list of CIDR strings
+func NewCidrRanges(cidrs []string) (CidrRanges, error) {
+	var ranges CidrRanges
+	for _, cidr := range cidrs {
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+		}
+		ranges = append(ranges, ipnet)
+	}
+	return ranges, nil
+}
+
+// Contains returns true if the given IP is within any of the CIDR ranges
+func (c CidrRanges) Contains(ip net.IP) bool {
+	for _, ipnet := range c {
+		if ipnet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/netutil/ip_ranges.go
+++ b/netutil/ip_ranges.go
@@ -10,12 +10,12 @@ import (
 const DefaultPrivateIPRanges = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8,169.254.0.0/16,fc00::/7,fe80::/10"
 
 // PrivateCidrRanges holds the default private IP ranges
-var PrivateCidrRanges CidrRanges
+var DefaultPrivateCidrRanges CIDRs
 
 func init() {
 	// Initialize PrivateCidrRanges with default private IP ranges
 	var err error
-	PrivateCidrRanges, err = NewCidrRanges(
+	DefaultPrivateCidrRanges, err = NewCidrRanges(
 		strings.Split(DefaultPrivateIPRanges, ","),
 	)
 	if err != nil {
@@ -24,11 +24,11 @@ func init() {
 }
 
 // CidrRanges holds a list of parsed CIDR ranges
-type CidrRanges []*net.IPNet
+type CIDRs []*net.IPNet
 
 // NewCidrRanges initializes CidrRanges from a list of CIDR strings
-func NewCidrRanges(cidrs []string) (CidrRanges, error) {
-	var ranges CidrRanges
+func NewCidrRanges(cidrs []string) (CIDRs, error) {
+	var ranges CIDRs
 	for _, cidr := range cidrs {
 		_, ipnet, err := net.ParseCIDR(cidr)
 		if err != nil {
@@ -40,11 +40,20 @@ func NewCidrRanges(cidrs []string) (CidrRanges, error) {
 }
 
 // Contains returns true if the given IP is within any of the CIDR ranges
-func (c CidrRanges) Contains(ip net.IP) bool {
+func (c CIDRs) Contains(ip net.IP) bool {
 	for _, ipnet := range c {
 		if ipnet.Contains(ip) {
 			return true
 		}
 	}
 	return false
+}
+
+func (c CIDRs) String() string {
+	var sb strings.Builder
+	for _, ipnet := range c {
+		sb.WriteString(ipnet.String())
+		sb.WriteString(",")
+	}
+	return sb.String()
 }

--- a/netutil/ip_ranges_test.go
+++ b/netutil/ip_ranges_test.go
@@ -74,9 +74,16 @@ func TestCidrRanges_Contains(t *testing.T) {
 
 func TestPrivateCidrRanges_Defaults(t *testing.T) {
 	// Test that the default PrivateCidrRanges contains a known private IP
-	require.True(t, PrivateCidrRanges.Contains(net.ParseIP("10.0.0.1")))
-	require.True(t, PrivateCidrRanges.Contains(net.ParseIP("192.168.1.1")))
-	require.True(t, PrivateCidrRanges.Contains(net.ParseIP("fc00::1")))
-	require.False(t, PrivateCidrRanges.Contains(net.ParseIP("8.8.8.8")))
-	require.False(t, PrivateCidrRanges.Contains(net.ParseIP("2001:4860:4860::8888"))) // Google DNS IPv6
+	require.True(t, DefaultPrivateCidrRanges.Contains(net.ParseIP("10.0.0.1")))
+	require.True(t, DefaultPrivateCidrRanges.Contains(net.ParseIP("192.168.1.1")))
+	require.True(t, DefaultPrivateCidrRanges.Contains(net.ParseIP("fc00::1")))
+	require.False(t, DefaultPrivateCidrRanges.Contains(net.ParseIP("8.8.8.8")))
+	require.False(t, DefaultPrivateCidrRanges.Contains(net.ParseIP("2001:4860:4860::8888"))) // Google DNS IPv6
+}
+
+func TestCidrRanges_String(t *testing.T) {
+	cidrs := []string{"10.0.0.0/8", "192.168.0.0/16", "fc00::/7"}
+	ranges, err := NewCidrRanges(cidrs)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.0/8,192.168.0.0/16,fc00::/7", ranges.String())
 }

--- a/netutil/ip_ranges_test.go
+++ b/netutil/ip_ranges_test.go
@@ -1,0 +1,82 @@
+package netutil
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCidrRanges(t *testing.T) {
+	tests := []struct {
+		name      string
+		cidrs     []string
+		wantErr   bool
+		wantCount int
+	}{
+		{
+			name:      "valid IPv4 and IPv6 CIDRs",
+			cidrs:     []string{"10.0.0.0/8", "fc00::/7"},
+			wantErr:   false,
+			wantCount: 2,
+		},
+		{
+			name:      "invalid CIDR",
+			cidrs:     []string{"10.0.0.0/8", "invalid"},
+			wantErr:   true,
+			wantCount: 0,
+		},
+		{
+			name:      "empty CIDR list",
+			cidrs:     []string{},
+			wantErr:   false,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ranges, err := NewCidrRanges(tt.cidrs)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, ranges, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestCidrRanges_Contains(t *testing.T) {
+	cidrs := []string{"10.0.0.0/8", "192.168.0.0/16", "fc00::/7"}
+	ranges, err := NewCidrRanges(cidrs)
+	require.NoError(t, err)
+
+	tests := []struct {
+		ip      string
+		want    bool
+		comment string
+	}{
+		{"10.1.2.3", true, "in 10.0.0.0/8"},
+		{"192.168.1.1", true, "in 192.168.0.0/16"},
+		{"8.8.8.8", false, "not in any range"},
+		{"fc00::1", true, "in fc00::/7"},
+		{"fe80::1", false, "not in any range"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.Equal(t, tt.want, ranges.Contains(ip), tt.comment)
+		})
+	}
+}
+
+func TestPrivateCidrRanges_Defaults(t *testing.T) {
+	// Test that the default PrivateCidrRanges contains a known private IP
+	require.True(t, PrivateCidrRanges.Contains(net.ParseIP("10.0.0.1")))
+	require.True(t, PrivateCidrRanges.Contains(net.ParseIP("192.168.1.1")))
+	require.True(t, PrivateCidrRanges.Contains(net.ParseIP("fc00::1")))
+	require.False(t, PrivateCidrRanges.Contains(net.ParseIP("8.8.8.8")))
+	require.False(t, PrivateCidrRanges.Contains(net.ParseIP("2001:4860:4860::8888"))) // Google DNS IPv6
+}


### PR DESCRIPTION
# Description

This PR creates a new package `netutil` which generates CIDR ranges from an array of CIDRs and provides a helper function to check if an IP is part of those CIDR ranges

## Linear Ticket

Fixes PIPE-2064

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
