### PR TITLE
feat: add a retryable HTTP client with exponential backoff

### DIFF
--- a/retryablehttp/retryablehttp.go
+++ b/retryablehttp/retryablehttp.go
@@ -17,15 +17,15 @@ type HttpClient interface {
 
 type Config struct {
 	// MaxRetry is the maximum number of retries.
-	MaxRetry conf.ValueLoader[int]
+	MaxRetry int
 	//  InitialInterval is the initial interval between retries.
-	InitialInterval conf.ValueLoader[time.Duration]
+	InitialInterval time.Duration
 	// MaxInterval is the maximum interval between retries.
-	MaxInterval conf.ValueLoader[time.Duration]
+	MaxInterval time.Duration
 	// Multiplier is the multiplier used to calculate the next interval.
-	MaxElapsedTime conf.ValueLoader[time.Duration]
+	MaxElapsedTime time.Duration
 	// Multiplier is the multiplier used to increase the interval between retries.
-	Multiplier conf.ValueLoader[float64]
+	Multiplier float64
 }
 
 // NewDefaultConfig creates a new Config with default retry settings.
@@ -37,11 +37,11 @@ type Config struct {
 //	Multiplier: Backoff multiplier for retry intervals (default: 1.5)
 func NewDefaultConfig() *Config {
 	return &Config{
-		MaxRetry:        conf.GetReloadableIntVar(5, 1, "retryablehttp.maxRetry"),
-		InitialInterval: conf.GetReloadableDurationVar(100, time.Millisecond, "retryablehttp.initialInterval"),
-		MaxInterval:     conf.GetReloadableDurationVar(1000, time.Millisecond, "retryablehttp.maxInterval"),
-		MaxElapsedTime:  conf.GetReloadableDurationVar(10, time.Second, "retryablehttp.maxElapsedTime"),
-		Multiplier:      conf.GetReloadableFloat64Var(1.5, "retryablehttp.multiplier"),
+		MaxRetry:        conf.GetReloadableIntVar(5, 1, "retryablehttp.maxRetry").Load(),
+		InitialInterval: conf.GetReloadableDurationVar(100, time.Millisecond, "retryablehttp.initialInterval").Load(),
+		MaxInterval:     conf.GetReloadableDurationVar(1000, time.Millisecond, "retryablehttp.maxInterval").Load(),
+		MaxElapsedTime:  conf.GetReloadableDurationVar(10, time.Second, "retryablehttp.maxElapsedTime").Load(),
+		Multiplier:      conf.GetReloadableFloat64Var(1.5, "retryablehttp.multiplier").Load(),
 	}
 }
 
@@ -128,12 +128,12 @@ func (c *retryableHTTPClient) Do(method, url string, body io.Reader, headers map
 		},
 		backoff.WithMaxRetries(
 			backoff.NewExponentialBackOff(
-				backoff.WithInitialInterval(c.config.InitialInterval.Load()),
-				backoff.WithMaxInterval(c.config.MaxInterval.Load()),
-				backoff.WithMaxElapsedTime(c.config.MaxElapsedTime.Load()),
-				backoff.WithMultiplier(c.config.Multiplier.Load()),
+				backoff.WithInitialInterval(c.config.InitialInterval),
+				backoff.WithMaxInterval(c.config.MaxInterval),
+				backoff.WithMaxElapsedTime(c.config.MaxElapsedTime),
+				backoff.WithMultiplier(c.config.Multiplier),
 			),
-			uint64(c.config.MaxRetry.Load()),
+			uint64(c.config.MaxRetry),
 		),
 		func(err error, duration time.Duration) {
 			if c.onFailure != nil {

--- a/retryablehttp/retryablehttp.go
+++ b/retryablehttp/retryablehttp.go
@@ -41,11 +41,11 @@ type Config struct {
 //	Multiplier: Backoff multiplier for retry intervals (default: 1.5)
 func NewDefaultConfig() *Config {
 	return &Config{
-		MaxRetry:        conf.GetReloadableIntVar(5, 1, "retryablehttp.maxRetry").Load(),
-		InitialInterval: conf.GetReloadableDurationVar(100, time.Millisecond, "retryablehttp.initialInterval").Load(),
-		MaxInterval:     conf.GetReloadableDurationVar(1000, time.Millisecond, "retryablehttp.maxInterval").Load(),
-		MaxElapsedTime:  conf.GetReloadableDurationVar(10, time.Second, "retryablehttp.maxElapsedTime").Load(),
-		Multiplier:      conf.GetReloadableFloat64Var(1.5, "retryablehttp.multiplier").Load(),
+		MaxRetry:        conf.GetInt("retryablehttp.maxRetry", 5),
+		InitialInterval: conf.GetDuration("retryablehttp.initialInterval", 100, time.Millisecond),
+		MaxInterval:     conf.GetDuration("retryablehttp.maxInterval", 1000, time.Millisecond),
+		MaxElapsedTime:  conf.GetDuration("retryablehttp.maxElapsedTime", 10, time.Second),
+		Multiplier:      conf.GetFloat64("retryablehttp.multiplier", 1.5),
 	}
 }
 

--- a/retryablehttp/retryablehttp.go
+++ b/retryablehttp/retryablehttp.go
@@ -1,0 +1,144 @@
+package retryablehttp
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	conf "github.com/rudderlabs/rudder-go-kit/config"
+)
+
+type HttpClient interface {
+	Do(method, url string, body io.Reader, headers map[string]string) (*http.Response, error)
+}
+
+type Config struct {
+	// MaxRetry is the maximum number of retries.
+	MaxRetry conf.ValueLoader[int]
+	//  InitialInterval is the initial interval between retries.
+	InitialInterval conf.ValueLoader[time.Duration]
+	// MaxInterval is the maximum interval between retries.
+	MaxInterval conf.ValueLoader[time.Duration]
+	// Multiplier is the multiplier used to calculate the next interval.
+	MaxElapsedTime conf.ValueLoader[time.Duration]
+	// Multiplier is the multiplier used to increase the interval between retries.
+	Multiplier conf.ValueLoader[float64]
+}
+
+// NewDefaultConfig creates a new Config with default retry settings.
+//
+//	MaxRetry: Maximum number of retries (default: 5)
+//	InitialInterval: Initial retry interval in milliseconds (default: 100ms)
+//	MaxInterval: Maximum retry interval in milliseconds (default: 1000ms)
+//	MaxElapsedTime: Maximum total elapsed time for retries in seconds (default: 10s)
+//	Multiplier: Backoff multiplier for retry intervals (default: 1.5)
+func NewDefaultConfig() *Config {
+	return &Config{
+		MaxRetry:        conf.GetReloadableIntVar(5, 1, "retryablehttp.maxRetry"),
+		InitialInterval: conf.GetReloadableDurationVar(100, time.Millisecond, "retryablehttp.initialInterval"),
+		MaxInterval:     conf.GetReloadableDurationVar(1000, time.Millisecond, "retryablehttp.maxInterval"),
+		MaxElapsedTime:  conf.GetReloadableDurationVar(10, time.Second, "retryablehttp.maxElapsedTime"),
+		Multiplier:      conf.GetReloadableFloat64Var(1.5, "retryablehttp.multiplier"),
+	}
+}
+
+type retryableHTTPClient struct {
+	*http.Client
+	config *Config
+	// onFailure is called when a retryable error occurs
+	onFailure func(err error, duration time.Duration)
+}
+
+type Option func(*retryableHTTPClient)
+
+func WithHttpClient(client *http.Client) Option {
+	return func(retryableHTTPClient *retryableHTTPClient) {
+		retryableHTTPClient.Client = client
+	}
+}
+
+func WithOnFailure(onFailure func(err error, duration time.Duration)) Option {
+	return func(retryableHTTPClient *retryableHTTPClient) {
+		retryableHTTPClient.onFailure = onFailure
+	}
+}
+
+// NewRetryableHTTPClient creates a new retryable HTTP client with the specified configuration and options.
+// It uses the `backoff` package to implement retry logic for HTTP requests.
+// All the 5xx and 429 errors will be retried
+// The default retry strategy is exponential backoff
+// Parameters:
+// - config: Configuration for the exponential backoff strategy
+// - options: Optional functional options to further configure the client
+//
+// Returns:
+// - HttpClient: A configured retryable HTTP client
+//
+// The client is initialized with a transport that has:
+// - Keep-alives disabled
+// - Maximum 100 connections per host
+// - Maximum 10 idle connections per host
+// - Idle connection timeout of 30 seconds
+func NewRetryableHTTPClient(config *Config, options ...Option) HttpClient {
+	if config == nil {
+		config = NewDefaultConfig()
+	}
+	httpClient := &retryableHTTPClient{
+		Client: &http.Client{
+			Transport: &http.Transport{
+				DisableKeepAlives:   true,
+				MaxConnsPerHost:     100,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     30 * time.Second,
+			},
+		},
+		config: config,
+	}
+	for _, option := range options {
+		option(httpClient)
+	}
+	return httpClient
+}
+
+// Do executes an HTTP request with retry logic.
+func (c *retryableHTTPClient) Do(method, url string, body io.Reader, headers map[string]string) (*http.Response, error) {
+	var (
+		resp *http.Response
+		err  error
+	)
+
+	_ = backoff.RetryNotify(
+		func() error {
+			var req *http.Request
+			req, err = http.NewRequest(method, url, body)
+			if err == nil {
+				for key, value := range headers {
+					req.Header.Set(key, value)
+				}
+				resp, err = c.Client.Do(req) // nolint: bodyclose
+				// retry 5xx errors
+				if err == nil && (resp.StatusCode >= http.StatusInternalServerError || resp.StatusCode == http.StatusTooManyRequests) {
+					return fmt.Errorf("non-success status code: %d", resp.StatusCode)
+				}
+			}
+			return err
+		},
+		backoff.WithMaxRetries(
+			backoff.NewExponentialBackOff(
+				backoff.WithInitialInterval(c.config.InitialInterval.Load()),
+				backoff.WithMaxInterval(c.config.MaxInterval.Load()),
+				backoff.WithMaxElapsedTime(c.config.MaxElapsedTime.Load()),
+				backoff.WithMultiplier(c.config.Multiplier.Load()),
+			),
+			uint64(c.config.MaxRetry.Load()),
+		),
+		func(err error, duration time.Duration) {
+			if c.onFailure != nil {
+				c.onFailure(err, duration)
+			}
+		},
+	)
+	return resp, err
+}

--- a/retryablehttp/retryablehttp.go
+++ b/retryablehttp/retryablehttp.go
@@ -28,7 +28,7 @@ type Config struct {
 	InitialInterval time.Duration
 	// MaxInterval is the maximum interval between retries.
 	MaxInterval time.Duration
-	// Multiplier is the multiplier used to calculate the next interval.
+	// MaxElapsedTime is the maximum total elapsed time for retries.
 	MaxElapsedTime time.Duration
 	// Multiplier is the multiplier used to increase the interval between retries.
 	Multiplier float64

--- a/retryablehttp/retryablehttp.go
+++ b/retryablehttp/retryablehttp.go
@@ -12,7 +12,7 @@ import (
 	conf "github.com/rudderlabs/rudder-go-kit/config"
 )
 
-type httpClient interface {
+type HttpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
@@ -35,7 +35,7 @@ type Config struct {
 }
 
 type retryableHTTPClient struct {
-	httpClient
+	HttpClient
 	config *Config
 	// shouldRetry is a function that determines whether to retry based on the response and error.
 	shouldRetry retryStrategy
@@ -45,9 +45,9 @@ type retryableHTTPClient struct {
 
 type Option func(*retryableHTTPClient)
 
-func WithHttpClient(client httpClient) Option {
+func WithHttpClient(client HttpClient) Option {
 	return func(retryableHTTPClient *retryableHTTPClient) {
-		retryableHTTPClient.httpClient = client
+		retryableHTTPClient.HttpClient = client
 	}
 }
 
@@ -96,12 +96,12 @@ func NewDefaultConfig() *Config {
 // - Maximum 100 connections per host
 // - Maximum 10 idle connections per host
 // - Idle connection timeout of 30 seconds
-func NewRetryableHTTPClient(config *Config, options ...Option) httpClient {
+func NewRetryableHTTPClient(config *Config, options ...Option) HttpClient {
 	if config == nil {
 		config = NewDefaultConfig()
 	}
 	client := &retryableHTTPClient{
-		httpClient: &http.Client{
+		HttpClient: &http.Client{
 			Transport: &http.Transport{
 				DisableKeepAlives:   true,
 				MaxConnsPerHost:     100,
@@ -142,7 +142,7 @@ func (c *retryableHTTPClient) Do(req *http.Request) (*http.Response, error) {
 					req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 				}
 			}
-			resp, err = c.httpClient.Do(req) // nolint: bodyclose
+			resp, err = c.HttpClient.Do(req) // nolint: bodyclose
 			if retry, retryErr := c.shouldRetry(resp, err); retry {
 				return fmt.Errorf("retryable error: %v", retryErr)
 			}

--- a/retryablehttp/retryablehttp.go
+++ b/retryablehttp/retryablehttp.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+
 	conf "github.com/rudderlabs/rudder-go-kit/config"
 )
 

--- a/retryablehttp/retryablehttp.go
+++ b/retryablehttp/retryablehttp.go
@@ -138,9 +138,7 @@ func (c *retryableHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		func() error {
 			// if the body was read, we need to reset it
 			if bodyBytes != nil {
-				if req.Body != http.NoBody {
-					req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-				}
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 			}
 			resp, err = c.HttpClient.Do(req) // nolint: bodyclose
 			if retry, retryErr := c.shouldRetry(resp, err); retry {

--- a/retryablehttp/retryablehttp.go
+++ b/retryablehttp/retryablehttp.go
@@ -58,7 +58,7 @@ type retryableHTTPClient struct {
 
 type Option func(*retryableHTTPClient)
 
-func WithHttpClient(client requestDoer) Option {
+func WithRequestDoer(client requestDoer) Option {
 	return func(retryableHTTPClient *retryableHTTPClient) {
 		retryableHTTPClient.requestDoer = client
 	}

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -1,0 +1,1 @@
+package retryablehttp

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	conf "github.com/rudderlabs/rudder-go-kit/config"
 )
 
 func TestRetryableHTTPClient_Do_SuccessNoRetry(t *testing.T) {
@@ -75,11 +73,11 @@ func TestRetryableHTTPClient_Do_RetryOn5xx(t *testing.T) {
 
 	// create client with custom config (faster retries for testing)
 	config := &Config{
-		MaxRetry:        conf.GetReloadableIntVar(3, 1, "maxRetry"),
-		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
-		MaxInterval:     conf.GetReloadableDurationVar(50, time.Millisecond, "maxInterval"),
-		MaxElapsedTime:  conf.GetReloadableDurationVar(1, time.Second, "maxElapsedTime"),
-		Multiplier:      conf.GetReloadableFloat64Var(1.5, "multiplier"),
+		MaxRetry:        3,
+		InitialInterval: 10 * time.Millisecond,
+		MaxInterval:     50 * time.Millisecond,
+		MaxElapsedTime:  time.Second,
+		Multiplier:      1.5,
 	}
 	client := NewRetryableHTTPClient(config)
 
@@ -111,11 +109,11 @@ func TestRetryableHTTPClient_Do_RetryOn429(t *testing.T) {
 
 	// create client with custom config (faster retries for testing)
 	config := &Config{
-		MaxRetry:        conf.GetReloadableIntVar(3, 1, "maxRetry"),
-		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
-		MaxInterval:     conf.GetReloadableDurationVar(50, time.Millisecond, "maxInterval"),
-		MaxElapsedTime:  conf.GetReloadableDurationVar(1, time.Second, "maxElapsedTime"),
-		Multiplier:      conf.GetReloadableFloat64Var(1.5, "multiplier"),
+		MaxRetry:        3,
+		InitialInterval: 10 * time.Millisecond,
+		MaxInterval:     50 * time.Millisecond,
+		MaxElapsedTime:  time.Second,
+		Multiplier:      1.5,
 	}
 	client := NewRetryableHTTPClient(config)
 
@@ -141,11 +139,11 @@ func TestRetryableHTTPClient_Do_MaxRetriesExceeded(t *testing.T) {
 
 	// create client with limited retries
 	config := &Config{
-		MaxRetry:        conf.GetReloadableIntVar(2, 1, "maxRetry2"),
-		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
-		MaxInterval:     conf.GetReloadableDurationVar(50, time.Millisecond, "maxInterval"),
-		MaxElapsedTime:  conf.GetReloadableDurationVar(1, time.Second, "maxElapsedTime"),
-		Multiplier:      conf.GetReloadableFloat64Var(1.5, "multiplier"),
+		MaxRetry:        2,
+		InitialInterval: 10 * time.Millisecond,
+		MaxInterval:     50 * time.Millisecond,
+		MaxElapsedTime:  time.Second,
+		Multiplier:      1.5,
 	}
 	client := NewRetryableHTTPClient(config)
 
@@ -216,11 +214,11 @@ func TestRetryableHTTPClient_WithOnFailure(t *testing.T) {
 
 	// create client with onFailure callback
 	config := &Config{
-		MaxRetry:        conf.GetReloadableIntVar(3, 1, "maxRetry"),
-		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
-		MaxInterval:     conf.GetReloadableDurationVar(50, time.Millisecond, "maxInterval"),
-		MaxElapsedTime:  conf.GetReloadableDurationVar(1, time.Second, "maxElapsedTime"),
-		Multiplier:      conf.GetReloadableFloat64Var(1.5, "multiplier"),
+		MaxRetry:        3,
+		InitialInterval: 10 * time.Millisecond,
+		MaxInterval:     50 * time.Millisecond,
+		MaxElapsedTime:  time.Second,
+		Multiplier:      1.5,
 	}
 	client := NewRetryableHTTPClient(config, WithOnFailure(onFailure))
 
@@ -249,9 +247,9 @@ func TestRetryableHTTPClient_RequestCreationError(t *testing.T) {
 func TestNewDefaultConfig(t *testing.T) {
 	config := NewDefaultConfig()
 
-	require.Equal(t, 5, config.MaxRetry.Load())
-	require.Equal(t, 100*time.Millisecond, config.InitialInterval.Load())
-	require.Equal(t, 1000*time.Millisecond, config.MaxInterval.Load())
-	require.Equal(t, 10*time.Second, config.MaxElapsedTime.Load())
-	require.Equal(t, 1.5, config.Multiplier.Load())
+	require.Equal(t, 5, config.MaxRetry)
+	require.Equal(t, 100*time.Millisecond, config.InitialInterval)
+	require.Equal(t, 1000*time.Millisecond, config.MaxInterval)
+	require.Equal(t, 10*time.Second, config.MaxElapsedTime)
+	require.Equal(t, 1.5, config.Multiplier)
 }

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -30,7 +30,8 @@ func TestRetryableHTTPClient_Do_SuccessNoRetry(t *testing.T) {
 
 		// return success
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, err = w.Write([]byte(`{"status":"ok"}`))
+		require.NoError(t, err)
 	}))
 	defer ts.Close()
 
@@ -67,7 +68,8 @@ func TestRetryableHTTPClient_Do_RetryOn5xx(t *testing.T) {
 		}
 		// return success on third attempt
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, err := w.Write([]byte(`{"status":"ok"}`))
+		require.NoError(t, err)
 	}))
 	defer ts.Close()
 
@@ -239,8 +241,7 @@ func TestRetryableHTTPClient_RequestCreationError(t *testing.T) {
 	client := NewRetryableHTTPClient(nil)
 
 	// use invalid URL to trigger request creation error
-	resp, err := client.Do(http.MethodGet, "://invalid-url", nil, nil)
-
+	resp, err := client.Do(http.MethodGet, "://invalid-url", nil, nil) // nolint: bodyclose
 	require.Error(t, err)
 	require.Nil(t, resp)
 }

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -241,7 +241,7 @@ func TestRetryableHTTPClient_WithCustomOptions(t *testing.T) {
 	// verify the client was set correctly (using type assertion)
 	retryClient, ok := client.(*retryableHTTPClient)
 	require.True(t, ok)
-	require.Equal(t, customHTTPClient, retryClient.httpClient)
+	require.Equal(t, customHTTPClient, retryClient.HttpClient)
 
 	// make request to verify it works
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -171,7 +171,7 @@ func TestRetryableHTTPClient_WithCustomOptions(t *testing.T) {
 	}
 
 	// create retryable client with custom HTTP client
-	client := NewRetryableHTTPClient(nil, WithHttpClient(customHTTPClient))
+	client := NewRetryableHTTPClient(nil, WithRequestDoer(customHTTPClient))
 
 	// verify the client was set correctly (using type assertion)
 	retryClient, ok := client.(*retryableHTTPClient)

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -40,7 +40,7 @@ func TestRetryableHTTPClient_Do_SuccessNoRetry(t *testing.T) {
 	// make request
 	body := strings.NewReader(`{"test":"data"}`)
 	headers := map[string]string{"Content-Type": "application/json"}
-	resp, err := client.Do(http.MethodPost, ts.URL, body, headers)
+	resp, err := client.Do(http.MethodPost, ts.URL, body, WithHeaders(headers))
 
 	// assertions
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestRetryableHTTPClient_Do_PostRetryOn5xx(t *testing.T) {
 	// make request
 	body := strings.NewReader(`{"test":"data"}`)
 	headers := map[string]string{"Content-Type": "application/json"}
-	resp, err := client.Do(http.MethodPost, ts.URL, body, headers)
+	resp, err := client.Do(http.MethodPost, ts.URL, body, WithHeaders(headers))
 
 	// assertions
 	require.NoError(t, err)

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -1,1 +1,256 @@
 package retryablehttp
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	conf "github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryableHTTPClient_Do_SuccessNoRetry(t *testing.T) {
+	// Set up test server
+	attempts := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		// Verify request details
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// Verify body
+		bodyBytes, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"test":"data"}`, string(bodyBytes))
+
+		// Return success
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer ts.Close()
+
+	// Create client with default config
+	client := NewRetryableHTTPClient(nil)
+
+	// Make request
+	body := strings.NewReader(`{"test":"data"}`)
+	headers := map[string]string{"Content-Type": "application/json"}
+	resp, err := client.Do(http.MethodPost, ts.URL, body, headers)
+
+	// Assertions
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 1, attempts) // Should not retry on success
+
+	// Check response body
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"status":"ok"}`, string(respBody))
+	resp.Body.Close()
+}
+
+func TestRetryableHTTPClient_Do_RetryOn5xx(t *testing.T) {
+	// Set up test server
+	var attempts int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			// Return server error for first two attempts
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// Return success on third attempt
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer ts.Close()
+
+	// Create client with custom config (faster retries for testing)
+	config := &Config{
+		MaxRetry:        conf.GetReloadableIntVar(3, 1, "maxRetry"),
+		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
+		MaxInterval:     conf.GetReloadableDurationVar(50, time.Millisecond, "maxInterval"),
+		MaxElapsedTime:  conf.GetReloadableDurationVar(1, time.Second, "maxElapsedTime"),
+		Multiplier:      conf.GetReloadableFloat64Var(1.5, "multiplier"),
+	}
+	client := NewRetryableHTTPClient(config)
+
+	// Make request
+	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
+
+	// Assertions
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, attempts) // Should retry twice then succeed on third try
+	resp.Body.Close()
+}
+
+func TestRetryableHTTPClient_Do_RetryOn429(t *testing.T) {
+	// Set up test server
+	var attempts int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			// Return rate limit error for first two attempts
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		// Return success on third attempt
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Create client with custom config (faster retries for testing)
+	config := &Config{
+		MaxRetry:        conf.GetReloadableIntVar(3, 1, "maxRetry"),
+		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
+		MaxInterval:     conf.GetReloadableDurationVar(50, time.Millisecond, "maxInterval"),
+		MaxElapsedTime:  conf.GetReloadableDurationVar(1, time.Second, "maxElapsedTime"),
+		Multiplier:      conf.GetReloadableFloat64Var(1.5, "multiplier"),
+	}
+	client := NewRetryableHTTPClient(config)
+
+	// Make request
+	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
+
+	// Assertions
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, attempts) // Should retry twice then succeed
+	resp.Body.Close()
+}
+
+func TestRetryableHTTPClient_Do_MaxRetriesExceeded(t *testing.T) {
+	// Set up test server that always returns server error
+	var attempts int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	// Create client with limited retries
+	config := &Config{
+		MaxRetry:        conf.GetReloadableIntVar(2, 1, "maxRetry2"),
+		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
+		MaxInterval:     conf.GetReloadableDurationVar(50, time.Millisecond, "maxInterval"),
+		MaxElapsedTime:  conf.GetReloadableDurationVar(1, time.Second, "maxElapsedTime"),
+		Multiplier:      conf.GetReloadableFloat64Var(1.5, "multiplier"),
+	}
+	client := NewRetryableHTTPClient(config)
+
+	// Make request
+	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
+
+	// Assertions - should return the last failed response after max retries
+	require.NoError(t, err) // Error is not returned, only the failed response
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, 3, attempts) // Initial + 2 retries
+	resp.Body.Close()
+}
+
+func TestRetryableHTTPClient_WithCustomOptions(t *testing.T) {
+	// Set up a successful test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// Create custom HTTP client
+	customHTTPClient := &http.Client{
+		Timeout: 500 * time.Millisecond,
+	}
+
+	// Create retryable client with custom HTTP client
+	client := NewRetryableHTTPClient(nil, WithHttpClient(customHTTPClient))
+
+	// Verify the client was set correctly (using type assertion)
+	retryClient, ok := client.(*retryableHTTPClient)
+	require.True(t, ok)
+	assert.Equal(t, customHTTPClient, retryClient.Client)
+
+	// Make request to verify it works
+	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestRetryableHTTPClient_WithOnFailure(t *testing.T) {
+	// Set up test server
+	var attempts int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	// Variables to track callback invocation
+	var (
+		failureCallCount int
+		lastError        error
+		mu               sync.Mutex
+	)
+
+	onFailure := func(err error, duration time.Duration) {
+		mu.Lock()
+		defer mu.Unlock()
+		failureCallCount++
+		lastError = err
+	}
+
+	// Create client with onFailure callback
+	config := &Config{
+		MaxRetry:        conf.GetReloadableIntVar(3, 1, "maxRetry"),
+		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
+		MaxInterval:     conf.GetReloadableDurationVar(50, time.Millisecond, "maxInterval"),
+		MaxElapsedTime:  conf.GetReloadableDurationVar(1, time.Second, "maxElapsedTime"),
+		Multiplier:      conf.GetReloadableFloat64Var(1.5, "multiplier"),
+	}
+	client := NewRetryableHTTPClient(config, WithOnFailure(onFailure))
+
+	// Make request
+	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Verify callback was called correctly
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, failureCallCount)
+	assert.Contains(t, lastError.Error(), "non-success status code: 500")
+}
+
+func TestRetryableHTTPClient_RequestCreationError(t *testing.T) {
+	client := NewRetryableHTTPClient(nil)
+
+	// Use invalid URL to trigger request creation error
+	resp, err := client.Do(http.MethodGet, "://invalid-url", nil, nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestNewDefaultConfig(t *testing.T) {
+	config := NewDefaultConfig()
+
+	assert.Equal(t, 5, config.MaxRetry.Load())
+	assert.Equal(t, 100*time.Millisecond, config.InitialInterval.Load())
+	assert.Equal(t, 1000*time.Millisecond, config.MaxInterval.Load())
+	assert.Equal(t, 10*time.Second, config.MaxElapsedTime.Load())
+	assert.Equal(t, 1.5, config.Multiplier.Load())
+}

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -9,40 +9,40 @@ import (
 	"testing"
 	"time"
 
-	conf "github.com/rudderlabs/rudder-go-kit/config"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	conf "github.com/rudderlabs/rudder-go-kit/config"
 )
 
 func TestRetryableHTTPClient_Do_SuccessNoRetry(t *testing.T) {
-	// Set up test server
+	// set up test server
 	attempts := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
-		// Verify request details
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		// verify request details
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
-		// Verify body
+		// verify body
 		bodyBytes, err := io.ReadAll(r.Body)
-		assert.NoError(t, err)
-		assert.Equal(t, `{"test":"data"}`, string(bodyBytes))
+		require.NoError(t, err)
+		require.Equal(t, `{"test":"data"}`, string(bodyBytes))
 
-		// Return success
+		// return success
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"ok"}`))
 	}))
 	defer ts.Close()
 
-	// Create client with default config
+	// create client with default config
 	client := NewRetryableHTTPClient(nil)
 
-	// Make request
+	// make request
 	body := strings.NewReader(`{"test":"data"}`)
 	headers := map[string]string{"Content-Type": "application/json"}
 	resp, err := client.Do(http.MethodPost, ts.URL, body, headers)
 
-	// Assertions
+	// assertions
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -56,22 +56,22 @@ func TestRetryableHTTPClient_Do_SuccessNoRetry(t *testing.T) {
 }
 
 func TestRetryableHTTPClient_Do_RetryOn5xx(t *testing.T) {
-	// Set up test server
+	// set up test server
 	var attempts int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
 		if attempts < 3 {
-			// Return server error for first two attempts
+			// return server error for first two attempts
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		// Return success on third attempt
+		// return success on third attempt
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"ok"}`))
 	}))
 	defer ts.Close()
 
-	// Create client with custom config (faster retries for testing)
+	// create client with custom config (faster retries for testing)
 	config := &Config{
 		MaxRetry:        conf.GetReloadableIntVar(3, 1, "maxRetry"),
 		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
@@ -81,19 +81,19 @@ func TestRetryableHTTPClient_Do_RetryOn5xx(t *testing.T) {
 	}
 	client := NewRetryableHTTPClient(config)
 
-	// Make request
+	// make request
 	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
 
-	// Assertions
+	// assertions
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, 3, attempts) // Should retry twice then succeed on third try
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 3, attempts) // Should retry twice then succeed on third try
 	resp.Body.Close()
 }
 
 func TestRetryableHTTPClient_Do_RetryOn429(t *testing.T) {
-	// Set up test server
+	// set up test server
 	var attempts int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
@@ -107,7 +107,7 @@ func TestRetryableHTTPClient_Do_RetryOn429(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	// Create client with custom config (faster retries for testing)
+	// create client with custom config (faster retries for testing)
 	config := &Config{
 		MaxRetry:        conf.GetReloadableIntVar(3, 1, "maxRetry"),
 		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
@@ -117,19 +117,19 @@ func TestRetryableHTTPClient_Do_RetryOn429(t *testing.T) {
 	}
 	client := NewRetryableHTTPClient(config)
 
-	// Make request
+	// make request
 	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
 
-	// Assertions
+	// assertions
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, 3, attempts) // Should retry twice then succeed
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 3, attempts) // Should retry twice then succeed
 	resp.Body.Close()
 }
 
 func TestRetryableHTTPClient_Do_MaxRetriesExceeded(t *testing.T) {
-	// Set up test server that always returns server error
+	// set up test server that always returns server error
 	var attempts int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
@@ -137,7 +137,7 @@ func TestRetryableHTTPClient_Do_MaxRetriesExceeded(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	// Create client with limited retries
+	// create client with limited retries
 	config := &Config{
 		MaxRetry:        conf.GetReloadableIntVar(2, 1, "maxRetry2"),
 		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
@@ -147,46 +147,46 @@ func TestRetryableHTTPClient_Do_MaxRetriesExceeded(t *testing.T) {
 	}
 	client := NewRetryableHTTPClient(config)
 
-	// Make request
+	// make request
 	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
 
-	// Assertions - should return the last failed response after max retries
+	// assertions - should return the last failed response after max retries
 	require.NoError(t, err) // Error is not returned, only the failed response
 	require.NotNil(t, resp)
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
-	assert.Equal(t, 3, attempts) // Initial + 2 retries
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	require.Equal(t, 3, attempts) // Initial + 2 retries
 	resp.Body.Close()
 }
 
 func TestRetryableHTTPClient_WithCustomOptions(t *testing.T) {
-	// Set up a successful test server
+	// set up a successful test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
 
-	// Create custom HTTP client
+	// create custom HTTP client
 	customHTTPClient := &http.Client{
 		Timeout: 500 * time.Millisecond,
 	}
 
-	// Create retryable client with custom HTTP client
+	// create retryable client with custom HTTP client
 	client := NewRetryableHTTPClient(nil, WithHttpClient(customHTTPClient))
 
-	// Verify the client was set correctly (using type assertion)
+	// verify the client was set correctly (using type assertion)
 	retryClient, ok := client.(*retryableHTTPClient)
 	require.True(t, ok)
-	assert.Equal(t, customHTTPClient, retryClient.Client)
+	require.Equal(t, customHTTPClient, retryClient.Client)
 
-	// Make request to verify it works
+	// make request to verify it works
 	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
 }
 
 func TestRetryableHTTPClient_WithOnFailure(t *testing.T) {
-	// Set up test server
+	// set up test server
 	var attempts int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
@@ -198,7 +198,7 @@ func TestRetryableHTTPClient_WithOnFailure(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	// Variables to track callback invocation
+	// variables to track callback invocation
 	var (
 		failureCallCount int
 		lastError        error
@@ -212,7 +212,7 @@ func TestRetryableHTTPClient_WithOnFailure(t *testing.T) {
 		lastError = err
 	}
 
-	// Create client with onFailure callback
+	// create client with onFailure callback
 	config := &Config{
 		MaxRetry:        conf.GetReloadableIntVar(3, 1, "maxRetry"),
 		InitialInterval: conf.GetReloadableDurationVar(10, time.Millisecond, "initialInterval"),
@@ -222,35 +222,35 @@ func TestRetryableHTTPClient_WithOnFailure(t *testing.T) {
 	}
 	client := NewRetryableHTTPClient(config, WithOnFailure(onFailure))
 
-	// Make request
+	// make request
 	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
 
-	// Verify callback was called correctly
+	// verify callback was called correctly
 	mu.Lock()
 	defer mu.Unlock()
-	assert.Equal(t, 1, failureCallCount)
-	assert.Contains(t, lastError.Error(), "non-success status code: 500")
+	require.Equal(t, 1, failureCallCount)
+	require.Contains(t, lastError.Error(), "non-success status code: 500")
 }
 
 func TestRetryableHTTPClient_RequestCreationError(t *testing.T) {
 	client := NewRetryableHTTPClient(nil)
 
-	// Use invalid URL to trigger request creation error
+	// use invalid URL to trigger request creation error
 	resp, err := client.Do(http.MethodGet, "://invalid-url", nil, nil)
 
-	assert.Error(t, err)
-	assert.Nil(t, resp)
+	require.Error(t, err)
+	require.Nil(t, resp)
 }
 
 func TestNewDefaultConfig(t *testing.T) {
 	config := NewDefaultConfig()
 
-	assert.Equal(t, 5, config.MaxRetry.Load())
-	assert.Equal(t, 100*time.Millisecond, config.InitialInterval.Load())
-	assert.Equal(t, 1000*time.Millisecond, config.MaxInterval.Load())
-	assert.Equal(t, 10*time.Second, config.MaxElapsedTime.Load())
-	assert.Equal(t, 1.5, config.Multiplier.Load())
+	require.Equal(t, 5, config.MaxRetry.Load())
+	require.Equal(t, 100*time.Millisecond, config.InitialInterval.Load())
+	require.Equal(t, 1000*time.Millisecond, config.MaxInterval.Load())
+	require.Equal(t, 10*time.Second, config.MaxElapsedTime.Load())
+	require.Equal(t, 1.5, config.Multiplier.Load())
 }

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -176,7 +176,7 @@ func TestRetryableHTTPClient_WithCustomOptions(t *testing.T) {
 	// verify the client was set correctly (using type assertion)
 	retryClient, ok := client.(*retryableHTTPClient)
 	require.True(t, ok)
-	require.Equal(t, customHTTPClient, retryClient.Client)
+	require.Equal(t, customHTTPClient, retryClient.requestDoer)
 
 	// make request to verify it works
 	resp, err := client.Do(http.MethodGet, ts.URL, nil, nil)


### PR DESCRIPTION
# Description

add a retryable HTTP client with exponential backoff

## Linear Ticket

pipe-2105

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
