### PR TITLE
chore: sonnet should use its own marshaller in jsonrs

### DIFF
--- a/jsonrs/sonnet.go
+++ b/jsonrs/sonnet.go
@@ -39,12 +39,7 @@ func (j *sonnetJSON) NewDecoder(r io.Reader) Decoder {
 }
 
 func (j *sonnetJSON) NewEncoder(w io.Writer) Encoder {
-	// always using jsoniter for streaming due to: https://github.com/go-json-experiment/jsonbench?tab=readme-ov-file#streaming
-	return defaultJsoniter.NewEncoder(w)
-
-	// TODO: if we were to enable sonnet streaming it would be unreliable.
-	// Issue is easy to reproduce by running warehouse api tests with sonnet streaming enabled
-	// return sonnet.NewEncoder(w)
+	return sonnet.NewEncoder(w)
 }
 
 func (j *sonnetJSON) Valid(data []byte) bool {


### PR DESCRIPTION
# Description

- sonnet's marshaller doesn't have streaming issues like its unmarshaller does
- sonnet's marshaller is 2x faster than jsoniter
- sonnet's marshaller is more compatible to std json library than jsoniter is

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
