### PR TITLE
feat: add support for concurrent delete object requests for GCS

### DIFF
--- a/filemanager/filemanager.go
+++ b/filemanager/filemanager.go
@@ -90,7 +90,7 @@ func New(settings *Settings) (FileManager, error) {
 	case "S3_DATALAKE", "S3":
 		return NewS3Manager(conf, settings.Config, log, getDefaultTimeout(conf, settings.Provider))
 	case "GCS":
-		return NewGCSManager(settings.Config, log, getDefaultTimeout(conf, settings.Provider))
+		return NewGCSManager(settings.Config, log, getDefaultTimeout(conf, settings.Provider), WithConcurrentDeleteObjRequests(conf.GetInt("FileManager.GCS.concurrentDeleteObjRequests", 1)))
 	case "AZURE_BLOB":
 		return NewAzureBlobManager(settings.Config, log, getDefaultTimeout(conf, settings.Provider))
 	case "MINIO":

--- a/filemanager/gcsmanager.go
+++ b/filemanager/gcsmanager.go
@@ -44,10 +44,10 @@ type GcsManager struct {
 	concurrentDeleteObjRequests int
 }
 
-// GcsManagerOption defines a function that configures a GcsManager
+// GcsManagerOption configures a GcsManager
 type GcsManagerOption func(*GcsManager)
 
-// WithConcurrentDeleteObjRequests sets the number of concurrent delete operations
+// WithConcurrentDeleteObjRequests sets the number of concurrent delete object requests
 func WithConcurrentDeleteObjRequests(limit int) GcsManagerOption {
 	return func(m *GcsManager) {
 		m.concurrentDeleteObjRequests = limit
@@ -67,10 +67,9 @@ func NewGCSManager(
 			defaultTimeout: defaultTimeout,
 		},
 		config:                      conf,
-		concurrentDeleteObjRequests: 1, // Default value
+		concurrentDeleteObjRequests: 1,
 	}
 
-	// Apply options
 	for _, opt := range opts {
 		opt(manager)
 	}

--- a/filemanager/gcsmanager_test.go
+++ b/filemanager/gcsmanager_test.go
@@ -199,12 +199,11 @@ func TestGCSManagerConcurrentDelete(t *testing.T) {
 				"endPoint":                    gcsURL,
 				"disableSSL":                  true,
 				"jsonReads":                   true,
-				"concurrentDeleteObjRequests": concurrency,
 			}
 
 			m, err := NewGCSManager(conf, logger.NOP, func() time.Duration {
 				return 5 * time.Minute
-			})
+			}, WithConcurrentDeleteObjRequests(concurrency))
 			require.NoError(t, err)
 
 			// Upload test objects

--- a/filemanager/gcsmanager_test.go
+++ b/filemanager/gcsmanager_test.go
@@ -90,13 +90,11 @@ func TestGCSManagerConcurrentDelete(t *testing.T) {
 	port, err := testhelper.GetFreePort()
 	require.NoError(t, err)
 
-	// Create a channel to track concurrent operations
 	activeOps := make(chan int, 1000)
 	maxConcurrent := 0
 	currentConcurrent := 0
 	var mu sync.Mutex
 
-	// Create fake GCS server
 	server, err := fakestorage.NewServerWithOptions(fakestorage.Options{
 		Scheme: "http",
 		Host:   "127.0.0.1",
@@ -105,7 +103,6 @@ func TestGCSManagerConcurrentDelete(t *testing.T) {
 	require.NoError(t, err)
 	defer server.Stop()
 
-	// port for the custom server with delete handler
 	customPort, err := testhelper.GetFreePort()
 	require.NoError(t, err)
 
@@ -140,7 +137,6 @@ func TestGCSManagerConcurrentDelete(t *testing.T) {
 				return
 			}
 
-			// Copy headers
 			for k, v := range r.Header {
 				forwardReq.Header[k] = v
 			}
@@ -161,7 +157,6 @@ func TestGCSManagerConcurrentDelete(t *testing.T) {
 		}),
 	}
 
-	// Start the server in a goroutine
 	go func() {
 		if err := fakeServerWithDeleteHandler.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			t.Errorf("custom server error: %v", err)
@@ -175,7 +170,6 @@ func TestGCSManagerConcurrentDelete(t *testing.T) {
 	gcsURL := fmt.Sprintf("http://127.0.0.1:%d/storage/v1/", customPort)
 	t.Log("GCS URL:", gcsURL)
 
-	// Test different concurrency levels
 	concurrencyLevels := []int{1, 10}
 	objectCount := 100
 
@@ -206,13 +200,11 @@ func TestGCSManagerConcurrentDelete(t *testing.T) {
 			}, WithConcurrentDeleteObjRequests(concurrency))
 			require.NoError(t, err)
 
-			// Upload test objects
 			keys := make([]string, objectCount)
 			for i := 0; i < objectCount; i++ {
 				objName := fmt.Sprintf("%s/obj-%d.txt", prefix, i)
 				content := []byte(fmt.Sprintf("data-%d", i))
 
-				// Upload object to fake server
 				server.CreateObject(fakestorage.Object{
 					ObjectAttrs: fakestorage.ObjectAttrs{
 						BucketName: bucketName,

--- a/filemanager/gcsmanager_test.go
+++ b/filemanager/gcsmanager_test.go
@@ -13,10 +13,11 @@ import (
 
 	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/testhelper"
-	"github.com/stretchr/testify/require"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 )

--- a/filemanager/gcsmanager_test.go
+++ b/filemanager/gcsmanager_test.go
@@ -194,11 +194,11 @@ func TestGCSManagerConcurrentDelete(t *testing.T) {
 			prefix := fmt.Sprintf("test-prefix-%d", concurrency)
 
 			conf := map[string]interface{}{
-				"bucketName":                  bucketName,
-				"prefix":                      prefix,
-				"endPoint":                    gcsURL,
-				"disableSSL":                  true,
-				"jsonReads":                   true,
+				"bucketName": bucketName,
+				"prefix":     prefix,
+				"endPoint":   gcsURL,
+				"disableSSL": true,
+				"jsonReads":  true,
 			}
 
 			m, err := NewGCSManager(conf, logger.NOP, func() time.Duration {

--- a/filemanager/gcsmanager_test.go
+++ b/filemanager/gcsmanager_test.go
@@ -2,15 +2,21 @@ package filemanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
 
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/rudderlabs/rudder-go-kit/testhelper"
+	"github.com/stretchr/testify/require"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 )
@@ -74,4 +80,165 @@ func TestGCSManager(t *testing.T) {
 		_, err = m.Upload(ctx, f)
 		require.NoError(t, err)
 	})
+}
+
+func TestGCSManagerConcurrentDelete(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	port, err := testhelper.GetFreePort()
+	require.NoError(t, err)
+
+	// Create a channel to track concurrent operations
+	activeOps := make(chan int, 1000)
+	maxConcurrent := 0
+	currentConcurrent := 0
+	var mu sync.Mutex
+
+	// Create fake GCS server
+	server, err := fakestorage.NewServerWithOptions(fakestorage.Options{
+		Scheme: "http",
+		Host:   "127.0.0.1",
+		Port:   uint16(port),
+	})
+	require.NoError(t, err)
+	defer server.Stop()
+
+	// port for the custom server with delete handler
+	customPort, err := testhelper.GetFreePort()
+	require.NoError(t, err)
+
+	fakeServerWithDeleteHandler := &http.Server{
+		Addr: fmt.Sprintf("127.0.0.1:%d", customPort),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				mu.Lock()
+				currentConcurrent++
+				if currentConcurrent > maxConcurrent {
+					maxConcurrent = currentConcurrent
+				}
+				mu.Unlock()
+
+				activeOps <- 1
+				defer func() {
+					<-activeOps
+					mu.Lock()
+					currentConcurrent--
+					mu.Unlock()
+				}()
+			}
+			// Create a new request to forward to the GCS server
+			forwardURL := fmt.Sprintf("%s%s", server.URL(), r.URL.Path)
+			if r.URL.RawQuery != "" {
+				forwardURL += "?" + r.URL.RawQuery
+			}
+
+			forwardReq, err := http.NewRequestWithContext(r.Context(), r.Method, forwardURL, r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			// Copy headers
+			for k, v := range r.Header {
+				forwardReq.Header[k] = v
+			}
+
+			resp, err := http.DefaultClient.Do(forwardReq)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			for k, v := range resp.Header {
+				w.Header()[k] = v
+			}
+			w.WriteHeader(resp.StatusCode)
+			_, _ = io.Copy(w, resp.Body)
+		}),
+	}
+
+	// Start the server in a goroutine
+	go func() {
+		if err := fakeServerWithDeleteHandler.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("custom server error: %v", err)
+		}
+	}()
+
+	defer func() {
+		_ = fakeServerWithDeleteHandler.Close()
+	}()
+
+	gcsURL := fmt.Sprintf("http://127.0.0.1:%d/storage/v1/", customPort)
+	t.Log("GCS URL:", gcsURL)
+
+	// Test different concurrency levels
+	concurrencyLevels := []int{1, 10}
+	objectCount := 100
+
+	bucketName := fmt.Sprintf("test-bucket-%s", rand.UniqueString(10))
+	server.CreateBucketWithOpts(fakestorage.CreateBucketOpts{
+		Name: bucketName,
+	})
+
+	for _, concurrency := range concurrencyLevels {
+		t.Run(fmt.Sprintf("concurrency_%d", concurrency), func(t *testing.T) {
+			mu.Lock()
+			maxConcurrent = 0
+			currentConcurrent = 0
+			mu.Unlock()
+
+			prefix := fmt.Sprintf("test-prefix-%d", concurrency)
+
+			conf := map[string]interface{}{
+				"bucketName":                  bucketName,
+				"prefix":                      prefix,
+				"endPoint":                    gcsURL,
+				"disableSSL":                  true,
+				"jsonReads":                   true,
+				"concurrentDeleteObjRequests": concurrency,
+			}
+
+			m, err := NewGCSManager(conf, logger.NOP, func() time.Duration {
+				return 5 * time.Minute
+			})
+			require.NoError(t, err)
+
+			// Upload test objects
+			keys := make([]string, objectCount)
+			for i := 0; i < objectCount; i++ {
+				objName := fmt.Sprintf("%s/obj-%d.txt", prefix, i)
+				content := []byte(fmt.Sprintf("data-%d", i))
+
+				// Upload object to fake server
+				server.CreateObject(fakestorage.Object{
+					ObjectAttrs: fakestorage.ObjectAttrs{
+						BucketName: bucketName,
+						Name:       objName,
+					},
+					Content: content,
+				})
+
+				keys[i] = objName
+			}
+
+			err = m.Delete(ctx, keys)
+			require.NoError(t, err)
+
+			for _, key := range keys {
+				_, err := server.GetObject(bucketName, key)
+				require.Error(t, err, "Object should be deleted")
+			}
+
+			require.LessOrEqual(t, maxConcurrent, concurrency,
+				"Maximum concurrent operations should not exceed configured concurrency")
+
+			if concurrency > 1 {
+				require.Greater(t, maxConcurrent, 1,
+					"Should have multiple concurrent operations when concurrency > 1")
+			}
+		})
+	}
 }


### PR DESCRIPTION
# Description

google storage client doesn't support [batch requests](https://cloud.google.com/storage/docs/batch#go-batch-requests) . Run each delete in a routine as client can be shared across multiple requests

## Linear Ticket

Part of war-736

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
