### PR TITLE
fix: improve error handling and clarify retry strategy behavior

### DIFF
--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -220,7 +220,7 @@ func TestRetryableHTTPClient_Do_MaxRetriesExceeded(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	require.Equal(t, 3, attempts) // Initial + 2 retries
-	resp.Body.Close()
+	_ = resp.Body.Close()
 }
 
 func TestRetryableHTTPClient_WithCustomOptions(t *testing.T) {


### PR DESCRIPTION
# Description

- Update retryStrategy function documentation to clarify behavior when retrying and when not retrying
- Fix error wrapping in retryablehttp.go to use %w for retryable errors
- Add test case for custom retry strategy that retries on normally non-retryable errors

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
