### PR TITLE
fix: non-reloadable config values getting updated during change detection

### DIFF
--- a/config/config_bool.go
+++ b/config/config_bool.go
@@ -83,7 +83,7 @@ func (c *Config) storeBoolVar(defaultValue bool, store func(bool), orderedKeys .
 func (c *Config) storeAndRegisterBoolVar(defaultValue bool, ptr any, store func(bool), orderedKeys ...string) {
 	c.storeBoolVar(defaultValue, store, orderedKeys...) // store before registering non-reloadable keys
 	registerNonReloadableConfigKeys(c, defaultValue, &configValue{
-		value:        ptr,
+		value:        *ptr.(*bool),
 		defaultValue: defaultValue,
 		keys:         orderedKeys,
 	})

--- a/config/config_changedetect.go
+++ b/config/config_changedetect.go
@@ -136,9 +136,8 @@ func (c *Config) getCurrentSettings() map[string]any {
 func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 	for _, configVal := range configMap {
 		key := strings.Join(configVal.keys, ",")
-		value := configVal.value
-		switch value := value.(type) {
-		case *int, *Reloadable[int]:
+		switch value := configVal.value.(type) {
+		case int, *Reloadable[int]:
 			var _value int
 			var isSet bool
 			for _, key := range configVal.keys {
@@ -153,15 +152,15 @@ func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 			}
 			_value = _value * configVal.multiplier.(int)
 			switch value := value.(type) {
-			case *int: // non-reloadable int
-				if *value != _value {
-					*value = _value
+			case int: // non-reloadable int
+				if value != _value {
+					configVal.value = _value
 					c.notifier.notifyNonReloadableConfigChange(key)
 				}
 			case *Reloadable[int]: // reloadable int
 				swapHotReloadableConfig(key, value, _value, compare[int](), c.notifier)
 			}
-		case *int64, *Reloadable[int64]:
+		case int64, *Reloadable[int64]:
 			var _value int64
 			var isSet bool
 			for _, key := range configVal.keys {
@@ -176,15 +175,15 @@ func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 			}
 			_value = _value * configVal.multiplier.(int64)
 			switch value := value.(type) {
-			case *int64: // non-reloadable int64
-				if *value != _value {
-					*value = _value
+			case int64: // non-reloadable int64
+				if value != _value {
+					configVal.value = _value
 					c.notifier.notifyNonReloadableConfigChange(key)
 				}
 			case *Reloadable[int64]: // reloadable int64
 				swapHotReloadableConfig(key, value, _value, compare[int64](), c.notifier)
 			}
-		case *string, *Reloadable[string]:
+		case string, *Reloadable[string]:
 			var _value string
 			var isSet bool
 			for _, key := range configVal.keys {
@@ -198,15 +197,15 @@ func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 				_value = configVal.defaultValue.(string)
 			}
 			switch value := value.(type) {
-			case *string: // non-reloadable string
-				if *value != _value {
-					*value = _value
+			case string: // non-reloadable string
+				if value != _value {
+					configVal.value = _value
 					c.notifier.notifyNonReloadableConfigChange(key)
 				}
 			case *Reloadable[string]: // reloadable string
 				swapHotReloadableConfig(key, value, _value, compare[string](), c.notifier)
 			}
-		case *time.Duration, *Reloadable[time.Duration]:
+		case time.Duration, *Reloadable[time.Duration]:
 			var _value time.Duration
 			var isSet bool
 			for _, key := range configVal.keys {
@@ -220,15 +219,15 @@ func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 				_value = time.Duration(configVal.defaultValue.(int64)) * configVal.multiplier.(time.Duration)
 			}
 			switch value := value.(type) {
-			case *time.Duration: // non-reloadable duration
-				if *value != _value {
-					*value = _value
+			case time.Duration: // non-reloadable duration
+				if value != _value {
+					configVal.value = _value
 					c.notifier.notifyNonReloadableConfigChange(key)
 				}
 			case *Reloadable[time.Duration]: // reloadable duration
 				swapHotReloadableConfig(key, value, _value, compare[time.Duration](), c.notifier)
 			}
-		case *bool, *Reloadable[bool]:
+		case bool, *Reloadable[bool]:
 			var _value bool
 			var isSet bool
 			for _, key := range configVal.keys {
@@ -242,15 +241,15 @@ func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 				_value = configVal.defaultValue.(bool)
 			}
 			switch value := value.(type) {
-			case *bool: // non-reloadable bool
-				if *value != _value {
-					*value = _value
+			case bool: // non-reloadable bool
+				if configVal.value != _value {
+					configVal.value = _value
 					c.notifier.notifyNonReloadableConfigChange(key)
 				}
 			case *Reloadable[bool]: // reloadable bool
 				swapHotReloadableConfig(key, value, _value, compare[bool](), c.notifier)
 			}
-		case *float64, *Reloadable[float64]:
+		case float64, *Reloadable[float64]:
 			var _value float64
 			var isSet bool
 			for _, key := range configVal.keys {
@@ -265,16 +264,16 @@ func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 			}
 			_value = _value * configVal.multiplier.(float64)
 			switch value := value.(type) {
-			case *float64: // non-reloadable float64
-				if *value != _value {
-					*value = _value
+			case float64: // non-reloadable float64
+				if configVal.value != _value {
+					configVal.value = _value
 					c.notifier.notifyNonReloadableConfigChange(key)
 				}
 			case *Reloadable[float64]: // reloadable float64
 				swapHotReloadableConfig(key, value, _value, compare[float64](), c.notifier)
 			}
 
-		case *[]string, *Reloadable[[]string]:
+		case []string, *Reloadable[[]string]:
 			var _value []string
 			var isSet bool
 			for _, key := range configVal.keys {
@@ -288,9 +287,9 @@ func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 				_value = configVal.defaultValue.([]string)
 			}
 			switch value := value.(type) {
-			case *[]string: // non-reloadable slice
-				if slices.Compare(*value, _value) != 0 {
-					*value = _value
+			case []string: // non-reloadable slice
+				if slices.Compare(value, _value) != 0 {
+					configVal.value = _value
 					c.notifier.notifyNonReloadableConfigChange(key)
 				}
 			case *Reloadable[[]string]: // reloadable slice
@@ -298,7 +297,7 @@ func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 					return slices.Compare(a, b) == 0
 				}, c.notifier)
 			}
-		case *map[string]any, *Reloadable[map[string]any]:
+		case map[string]any, *Reloadable[map[string]any]:
 			var _value map[string]any
 			var isSet bool
 			for _, key := range configVal.keys {
@@ -312,9 +311,9 @@ func (c *Config) checkConfigForChanges(configMap map[string]*configValue) {
 				_value = configVal.defaultValue.(map[string]any)
 			}
 			switch value := value.(type) {
-			case *map[string]any: // non-reloadable map
-				if !mapDeepEqual(*value, _value) {
-					*value = _value
+			case map[string]any: // non-reloadable map
+				if !mapDeepEqual(value, _value) {
+					configVal.value = _value
 					c.notifier.notifyNonReloadableConfigChange(key)
 				}
 			case *Reloadable[map[string]any]: // reloadable map

--- a/config/config_duration.go
+++ b/config/config_duration.go
@@ -112,7 +112,7 @@ func (c *Config) storeAndRegisterDurationVar(
 ) {
 	c.storeDurationVar(defaultValueInTimescaleUnits, timeScale, store, orderedKeys...) // store before registering non-reloadable keys
 	registerNonReloadableConfigKeys(c, time.Duration(defaultValueInTimescaleUnits)*timeScale, &configValue{
-		value:        ptr,
+		value:        *ptr.(*time.Duration),
 		multiplier:   timeScale,
 		defaultValue: defaultValueInTimescaleUnits,
 		keys:         orderedKeys,

--- a/config/config_float64.go
+++ b/config/config_float64.go
@@ -84,7 +84,7 @@ func (c *Config) storeFloat64Var(defaultValue float64, store func(float64), orde
 func (c *Config) storeAndRegisterFloat64Var(defaultValue float64, ptr any, store func(float64), orderedKeys ...string) {
 	c.storeFloat64Var(defaultValue, store, orderedKeys...) // store before registering non-reloadable keys
 	registerNonReloadableConfigKeys(c, defaultValue, &configValue{
-		value:        ptr,
+		value:        *ptr.(*float64),
 		multiplier:   1.0,
 		defaultValue: defaultValue,
 		keys:         orderedKeys,

--- a/config/config_int.go
+++ b/config/config_int.go
@@ -101,7 +101,7 @@ func (c *Config) storeIntVar(defaultValue, valueScale int, store func(int), orde
 func (c *Config) storeAndRegisterIntVar(defaultValue int, ptr any, valueScale int, store func(int), orderedKeys ...string) {
 	c.storeIntVar(defaultValue, valueScale, store, orderedKeys...) // store before registering non-reloadable keys
 	registerNonReloadableConfigKeys(c, defaultValue*valueScale, &configValue{
-		value:        ptr,
+		value:        *ptr.(*int),
 		multiplier:   valueScale,
 		defaultValue: defaultValue,
 		keys:         orderedKeys,

--- a/config/config_int64.go
+++ b/config/config_int64.go
@@ -84,7 +84,7 @@ func (c *Config) storeInt64Var(defaultValue, valueScale int64, store func(int64)
 func (c *Config) storeAndRegisterInt64Var(defaultValue int64, ptr any, valueScale int64, store func(int64), orderedKeys ...string) {
 	c.storeInt64Var(defaultValue, valueScale, store, orderedKeys...) // store before registering non-reloadable keys
 	registerNonReloadableConfigKeys(c, defaultValue*valueScale, &configValue{
-		value:        ptr,
+		value:        *ptr.(*int64),
 		multiplier:   valueScale,
 		defaultValue: defaultValue,
 		keys:         orderedKeys,

--- a/config/config_string.go
+++ b/config/config_string.go
@@ -100,7 +100,7 @@ func (c *Config) storeStringVar(defaultValue string, store func(string), ordered
 func (c *Config) storeAndRegisterStringVar(defaultValue string, ptr any, store func(string), orderedKeys ...string) {
 	c.storeStringVar(defaultValue, store, orderedKeys...) // store before registering non-reloadable keys
 	registerNonReloadableConfigKeys(c, defaultValue, &configValue{
-		value:        ptr,
+		value:        *ptr.(*string),
 		defaultValue: defaultValue,
 		keys:         orderedKeys,
 	})

--- a/config/config_stringmap.go
+++ b/config/config_stringmap.go
@@ -91,7 +91,7 @@ func (c *Config) storeStringMapVar(
 func (c *Config) storeAndRegisterStringMapVar(defaultValue map[string]any, ptr any, store func(map[string]any), orderedKeys ...string) {
 	c.storeStringMapVar(defaultValue, store, orderedKeys...) // store before registering non-reloadable keys
 	registerNonReloadableConfigKeys(c, defaultValue, &configValue{
-		value:        ptr,
+		value:        *ptr.(*map[string]any),
 		defaultValue: defaultValue,
 		keys:         orderedKeys,
 	})

--- a/config/config_stringslice.go
+++ b/config/config_stringslice.go
@@ -83,7 +83,7 @@ func (c *Config) storeStringSliceVar(defaultValue []string, store func([]string)
 func (c *Config) storeAndRegisterStringSliceVar(defaultValue []string, ptr any, store func([]string), orderedKeys ...string) {
 	c.storeStringSliceVar(defaultValue, store, orderedKeys...) // store before registering non-reloadable keys
 	registerNonReloadableConfigKeys(c, defaultValue, &configValue{
-		value:        ptr,
+		value:        *ptr.(*[]string),
 		defaultValue: defaultValue,
 		keys:         orderedKeys,
 	})


### PR DESCRIPTION
# Description

When performing advanced change detection for non-reloadable config values, we shouldn't be modifying the original value itself, but a copy of the original value. 
Otherwise, we are modifying a non-reloadable config variable and we are also causing a DATA RACE detection errors, since values are being modified while they are being read.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
