### PR TITLE
feat: add default HTTP client and options for custom transport and timeout

### DIFF
--- a/httputil/client.go
+++ b/httputil/client.go
@@ -10,9 +10,14 @@ import (
 const (
 	headerXForwardedFor = "X-Forwarded-For"
 
-	DefaultMaxIdleConnsPerHost = 10
-	DefaultMaxConnsPerHost     = 100
-	DefaultDisableKeepAlives   = true
+	DefaultMaxIdleConnsPerHost   = 10
+	DefaultMaxConnsPerHost       = 100
+	DefaultDisableKeepAlives     = false
+	DefaultForceHttp2            = true
+	DefaultMaxIdleConns          = 100
+	DefaultIdleConnTimeout       = 90 * time.Second
+	DefaultTLSHandshakeTimeout   = 10 * time.Second
+	DefaultExpectContinueTimeout = 1 * time.Second
 	// DefaultRequestTimeout is the default timeout for HTTP requests for default HttpClient.
 	DefaultRequestTimeout = 30 * time.Second
 )
@@ -39,10 +44,17 @@ func GetRequestIP(req *http.Request) string {
 }
 
 func DefaultTransport() *http.Transport {
-	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.DisableKeepAlives = DefaultDisableKeepAlives
-	tr.MaxConnsPerHost = DefaultMaxConnsPerHost
-	tr.MaxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
+	tr := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     DefaultForceHttp2,
+		MaxIdleConns:          DefaultMaxIdleConns,
+		IdleConnTimeout:       DefaultIdleConnTimeout,
+		TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
+		ExpectContinueTimeout: DefaultExpectContinueTimeout,
+		DisableKeepAlives:     DefaultDisableKeepAlives,
+		MaxConnsPerHost:       DefaultMaxConnsPerHost,
+		MaxIdleConnsPerHost:   DefaultMaxIdleConnsPerHost,
+	}
 	return tr
 }
 

--- a/httputil/client.go
+++ b/httputil/client.go
@@ -64,23 +64,6 @@ type HttpClientOptions func(*http.Client)
 // It disables keep-alives, sets max connections per host, and configures idle connection timeout.
 // This is useful for clients that need to make many short-lived requests without reusing connections.
 // It also sets a default timeout of 30 seconds.
-// e.g.
-//
-//	func Example() {
-//		// no need to use .Clone() since a new transport is built each time
-//		transport := httputil.DefaultTransport()
-//		transport.ForceAttemptHTTP2 = false
-//		client := httputil.NewHttpClient(httputil.WithTransport(transport))
-//		req, err := http.NewRequest("GET", "https://example.com", nil)
-//		if err != nil {
-//			panic(err)
-//		}
-//		resp, err := client.Do(req)
-//		if err != nil {
-//			panic(err)
-//		}
-//		_ = resp.Body.Close()
-//	}
 func DefaultHttpClient() *http.Client {
 	return &http.Client{
 		Transport: DefaultTransport(),
@@ -88,6 +71,14 @@ func DefaultHttpClient() *http.Client {
 	}
 }
 
+// NewHttpClient creates a configured HTTP client with customizable options.
+// It initializes a client with DefaultHttpClient settings and applies functional options.
+// Parameters:
+//   - options: Variadic list of HttpClientOptions functions to customize client behavior
+//
+// Retur
+// Returns:
+//   - *http.Client configured with specified options
 func NewHttpClient(options ...HttpClientOptions) *http.Client {
 	client := DefaultHttpClient()
 	for _, option := range options {

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -120,3 +120,32 @@ func TestNewHttpClientWithOptions(t *testing.T) {
 		})
 	}
 }
+
+func ExampleNewHttpClient() {
+	// no need to use .Clone() since a new transport is built each time
+	transport := httputil.DefaultTransport()
+	transport.ForceAttemptHTTP2 = false
+	client := httputil.NewHttpClient(httputil.WithTransport(transport))
+	req, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		panic(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	_ = resp.Body.Close()
+}
+
+func ExampleDefaultHttpClient() {
+	client := httputil.DefaultHttpClient()
+	req, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		panic(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	_ = resp.Body.Close()
+}

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -3,6 +3,7 @@ package httputil_test
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -43,6 +44,81 @@ func TestGetRequestIP(t *testing.T) {
 				RemoteAddr: testCase.remoteAddr,
 			}
 			require.Equal(t, testCase.expectedResult, httputil.GetRequestIP(req))
+		})
+	}
+}
+
+func TestDefaultHttpClient(t *testing.T) {
+	client := httputil.DefaultHttpClient()
+	require.NotNil(t, client)
+	require.Equal(t, httputil.DefaultRequestTimeout, client.Timeout)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.True(t, transport.DisableKeepAlives)
+	require.Equal(t, httputil.DefaultMaxConnsPerHost, transport.MaxConnsPerHost)
+	require.Equal(t, httputil.DefaultMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	require.Equal(t, httputil.DefaultIdleConnTimeout, transport.IdleConnTimeout)
+	require.Equal(t, httputil.DefaultTransport(), transport)
+}
+
+func TestNewHttpClientWithOptions(t *testing.T) {
+	customTransport := &http.Transport{
+		DisableKeepAlives: false,
+		Proxy:             http.ProxyURL(nil),
+	}
+	testCases := []struct {
+		name          string
+		options       []httputil.HttpClientOptions
+		expectedCheck func(*testing.T, *http.Client)
+	}{
+		{
+			name:    "No options",
+			options: nil,
+			expectedCheck: func(t *testing.T, client *http.Client) {
+				require.Equal(t, httputil.DefaultRequestTimeout, client.Timeout)
+				transport, ok := client.Transport.(*http.Transport)
+				require.True(t, ok)
+				require.True(t, transport.DisableKeepAlives)
+			},
+		},
+		{
+			name:    "WithTimeout",
+			options: []httputil.HttpClientOptions{httputil.WithTimeout(5 * time.Second)},
+			expectedCheck: func(t *testing.T, client *http.Client) {
+				require.Equal(t, 5*time.Second, client.Timeout)
+				transport, ok := client.Transport.(*http.Transport)
+				require.True(t, ok)
+				require.True(t, transport.DisableKeepAlives)
+			},
+		},
+		{
+			name:    "WithTransport",
+			options: []httputil.HttpClientOptions{httputil.WithTransport(customTransport)},
+			expectedCheck: func(t *testing.T, client *http.Client) {
+				require.NotNil(t, client)
+				require.Equal(t, httputil.DefaultRequestTimeout, client.Timeout)
+				require.Same(t, customTransport, client.Transport)
+			},
+		},
+		{
+			name: "Multiple options",
+			options: []httputil.HttpClientOptions{
+				httputil.WithTimeout(15 * time.Second),
+				httputil.WithTransport(customTransport),
+			},
+			expectedCheck: func(t *testing.T, client *http.Client) {
+				require.NotNil(t, client)
+				require.Equal(t, 15*time.Second, client.Timeout)
+				require.Same(t, customTransport, client.Transport)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := httputil.NewHttpClient(tc.options...)
+			tc.expectedCheck(t, client)
 		})
 	}
 }

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -77,7 +77,7 @@ func TestNewHttpClientWithOptions(t *testing.T) {
 				require.Equal(t, httputil.DefaultRequestTimeout, client.Timeout)
 				transport, ok := client.Transport.(*http.Transport)
 				require.True(t, ok)
-				require.True(t, transport.DisableKeepAlives)
+				require.False(t, transport.DisableKeepAlives)
 			},
 		},
 		{
@@ -87,7 +87,7 @@ func TestNewHttpClientWithOptions(t *testing.T) {
 				require.Equal(t, 5*time.Second, client.Timeout)
 				transport, ok := client.Transport.(*http.Transport)
 				require.True(t, ok)
-				require.True(t, transport.DisableKeepAlives)
+				require.False(t, transport.DisableKeepAlives)
 			},
 		},
 		{

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -58,8 +58,6 @@ func TestDefaultHttpClient(t *testing.T) {
 	require.True(t, transport.DisableKeepAlives)
 	require.Equal(t, httputil.DefaultMaxConnsPerHost, transport.MaxConnsPerHost)
 	require.Equal(t, httputil.DefaultMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
-	require.Equal(t, httputil.DefaultIdleConnTimeout, transport.IdleConnTimeout)
-	require.Equal(t, httputil.DefaultTransport(), transport)
 }
 
 func TestNewHttpClientWithOptions(t *testing.T) {


### PR DESCRIPTION
# Description

- Introduce DefaultHttpClient with pre-configured transport settings
- Add HttpClientOptions type for customizing HTTP client
- Implement WithTimeout and WithTransport options
- Update tests to cover new functionality

## Linear Ticket

pipe-2219

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
