### PR TITLE
chore: skip setting session region and ignore region fetch errors

### DIFF
--- a/filemanager/s3manager.go
+++ b/filemanager/s3manager.go
@@ -264,8 +264,6 @@ func (m *s3ManagerV1) GetSession(ctx context.Context) (*session.Session, error) 
 		}
 		m.config.Region = aws.String(region)
 		m.sessionConfig.Region = region
-	} else {
-		m.sessionConfig.Region = *m.config.Region
 	}
 
 	var err error

--- a/filemanager/s3manager_test.go
+++ b/filemanager/s3manager_test.go
@@ -1,16 +1,23 @@
 package filemanager
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/minio/minio-go/v7"
+	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/rudder-go-kit/awsutil"
 	"github.com/rudderlabs/rudder-go-kit/config"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	miniotest "github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/minio"
 )
 
 func TestNewS3ManagerWithNil(t *testing.T) {
@@ -132,4 +139,83 @@ func TestGetSessionWithIAMRole(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, awsSession)
 	assert.NotNil(t, s3Manager.session)
+}
+
+func TestEmptyRegion(t *testing.T) {
+	const (
+		prefix      = "some-prefix"
+		objectName  = "minio.object"
+		fileContent = "This is test content for download functionality"
+		// Expected error message when region is missing and bucket is wrong
+		expectedRegionError = "failed to download from S3: operation error S3: GetObject, failed to resolve service endpoint, endpoint rule error, A region must be set when sending requests to S3."
+	)
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	minioResource, err := miniotest.Setup(pool, t)
+	require.NoError(t, err)
+
+	// Upload test file using minio client
+	_, err = minioResource.Client.PutObject(context.Background(),
+		minioResource.BucketName, prefix+"/"+objectName,
+		bytes.NewReader([]byte(fileContent)), int64(len(fileContent)),
+		minio.PutObjectOptions{},
+	)
+	require.NoError(t, err)
+
+	createFileManager := func(configModifications map[string]interface{}) (FileManager, error) {
+		c := minioResource.ToFileManagerConfig(prefix)
+		c["region"] = ""
+		c["endPoint"] = "https://" + c["endPoint"].(string)
+
+		// Apply any config modifications
+		for key, value := range configModifications {
+			c[key] = value
+		}
+
+		config := config.New()
+		config.Set("FileManager.useAwsSdkV2", true)
+
+		return New(&Settings{
+			Provider: "S3",
+			Config:   c,
+			Conf:     config,
+		})
+	}
+
+	t.Run("should create a session and download file even when region is empty", func(t *testing.T) {
+		fm, err := createFileManager(nil)
+		require.NoError(t, err)
+
+		// Create temporary file for download
+		tempFile, err := os.CreateTemp(t.TempDir(), "downloaded-*.txt")
+		require.NoError(t, err)
+		defer tempFile.Close()
+
+		// Download the file
+		err = fm.Download(context.Background(), tempFile, prefix+"/"+objectName)
+		require.NoError(t, err)
+
+		// Read downloaded content
+		_, err = tempFile.Seek(0, 0) // Reset file pointer to beginning
+		require.NoError(t, err)
+		downloadedContent, err := io.ReadAll(tempFile)
+		require.NoError(t, err)
+
+		// Verify content matches
+		require.Equal(t, fileContent, string(downloadedContent))
+	})
+
+	t.Run("should try to download even if fetching region fails", func(t *testing.T) {
+		fm, err := createFileManager(map[string]interface{}{
+			"bucketName": "wrong-bucket-name",
+		})
+		require.NoError(t, err)
+
+		// Wrong bucket name will trigger region fetch failure
+		err = fm.Download(context.Background(), nil, prefix+"/"+objectName)
+		require.Error(t, err)
+		require.Equal(t, expectedRegionError, err.Error())
+	})
 }

--- a/filemanager/s3manager_v2.go
+++ b/filemanager/s3manager_v2.go
@@ -259,12 +259,14 @@ func (m *s3ManagerV2) getClient(ctx context.Context) (*s3.Client, error) {
 			Region: aws.ToString(&m.config.RegionHint),
 		}), m.config.Bucket)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get bucket region: %w", err)
+			m.logger.Errorn("Failed to fetch AWS region for bucket",
+				logger.NewStringField("bucket", m.config.Bucket), obskit.Error(err),
+			)
+			// Failed to get Region probably due to VPC restrictions
+			// Will proceed to try with AccessKeyID and AccessKey
 		}
 		m.config.Region = aws.String(region)
 		m.sessionConfig.Region = region
-	} else {
-		m.sessionConfig.Region = *m.config.Region
 	}
 
 	cnf, err := awsutil.CreateAWSConfig(ctx, m.sessionConfig)


### PR DESCRIPTION
# Description

## Changes
- Continue to create the S3 session in s3managerV2 even if fetching the region fails to keep the behaviour consistent with v1. 
- skip setting session region as it's already being done in `NewSimpleSessionConfig`

## Linear Ticket

< Linear_Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
