### PR TITLE
fix: s3 manager v2 with prefix sanitization and update tests

### DIFF
--- a/filemanager/filemanager_test.go
+++ b/filemanager/filemanager_test.go
@@ -264,7 +264,7 @@ func TestFileManager(t *testing.T) {
 			destName:      "S3",
 			otherPrefixes: []string{"other-prefix-1", "other-prefix-2"},
 			config: map[string]interface{}{
-				"bucketName":       fmt.Sprintf("%s/", bucket),
+				"bucketName":       bucket + "///",
 				"accessKeyID":      accessKeyId,
 				"accessKey":        secretAccessKey,
 				"enableSSE":        false,

--- a/filemanager/s3manager_v2.go
+++ b/filemanager/s3manager_v2.go
@@ -60,7 +60,7 @@ func newS3ManagerV2(
 		s3Config.Prefix = sanitizeKey(s3Config.Prefix)
 	}
 
-	s3Config.Bucket = strings.TrimSuffix(s3Config.Bucket, "/")
+	s3Config.Bucket = strings.TrimRight(s3Config.Bucket, "/")
 
 	return &s3ManagerV2{
 		baseManager: &baseManager{


### PR DESCRIPTION
# Description

sanitize prefix in case of s3_manager_v2 as v1 was handling extra `/` internally, but when there is / in prefix like /snowflake/rudderstack. things tend to misbehave.

## Linear Ticket

pipe-2218

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
