### PR TITLE
fix: transformerarm64 docker image exits with SIGSEGV after calling a user transformation

### DIFF
--- a/testhelper/docker/resource/transformer/transformer.go
+++ b/testhelper/docker/resource/transformer/transformer.go
@@ -133,6 +133,7 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource
 		exposedPorts: []string{"9090"},
 		envs: []string{
 			"CONFIG_BACKEND_URL=https://api.rudderstack.com",
+			"NODE_OPTIONS=--no-node-snapshot",
 		},
 		authConfig: docker.AuthConfiguration{},
 	}


### PR DESCRIPTION
# Description

isolated-vm needs [--no-node-snapshot](https://www.npmjs.com/package/isolated-vm#:~:text=%F0%9F%9A%A8%20If%20you%20are%20using%20a%20version%20of%20nodejs%2020.x%20or%20later%2C%20you%20must%20pass%20%2D%2Dno%2Dnode%2Dsnapshot%20to%20node.) which is not longer automatically provided in transformer's docker image

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
