### PR TITLE
chore: maxprocs to support vpa in-place

### DIFF
--- a/.ai-agent/guidelines.md
+++ b/.ai-agent/guidelines.md
@@ -1,0 +1,344 @@
+# AI Agent Guidelines
+
+All the rules below are not optional and must be followed to the letter.
+
+# Go Rules
+
+## rudder-go-kit
+
+https://github.com/rudderlabs/rudder-go-kit opinionated library for rudderstack. Should be used for all Golang projects,
+for common things like logging, config, http, etc.
+
+### HTTP
+
+import `github.com/rudderlabs/rudder-go-kit/httputil`
+
+#### Request
+
+When doing an HTTP request you must always close the response body. To do this:
+
+DO NOT use:
+
+```go
+    defer resp.Body.Close()
+```
+
+DO use:
+
+```go
+    defer func() { httputil.CloseResponse(resp) }()
+```
+
+#### Handlers
+
+Always use the standard http.Handler interface and return proper handlers:
+
+```go
+func SomeHandler() http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // handler logic
+    })
+}
+```
+
+### Logging
+
+Always use rudder-go-kit for logging.
+
+```go
+import (
+	"github.com/rudderlabs/rudder-go-kit/logger"
+    obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
+)
+```
+
+Non-sugared methods MUST BE used along with common fields from rudder-observability-kit when available.
+
+For example if a `sourceId` is available you must use `obskit.SourceID("some-source-id")`.
+These fields are available in the rudder-observability-kit:
+
+```go
+var (
+	DestinationID    = func(v string) log.Field { return log.NewStringField("destinationId", v) }
+	DestinationType  = func(v string) log.Field { return log.NewStringField("destinationType", v) }
+	SourceID         = func(v string) log.Field { return log.NewStringField("sourceId", v) }
+	SourceType       = func(v string) log.Field { return log.NewStringField("sourceType", v) }
+	WorkspaceID      = func(v string) log.Field { return log.NewStringField("workspaceId", v) }
+	TransformationID = func(v string) log.Field { return log.NewStringField("transformationId", v) }
+	Namespace        = func(v string) log.Field { return log.NewStringField("namespace", v) }
+	Error            = func(v error) log.Field { return log.NewErrorField(v) }
+)
+```
+
+Non-sugared log methods has `n` suffix.
+
+DO NOT:
+
+```go
+   fmt.Println("foo")
+   fmt.Printf("foo %d\n", i)
+```
+
+DO NOT:
+
+```go
+log.Info("starting", port, port)
+log.Infow("starting", port, port)
+log.Infof("starting port %d", port)
+```
+
+DO NOT do string formatting in message:
+
+```go
+log.Infon("starting on port %d", logger.NewIntField("port", int64(port)))
+```
+
+DO (descriptive message with structured fields):
+
+```go
+log.Infon("starting", logger.NewIntField("port", int64(port)))
+```
+
+DO NOT USE `logger.NewField` and use the strong-typed counterparts instead like `logger.NewStringField`,
+`logger.NewBooldField` etc...
+
+DO NOT USE reflection like `fmt.Sprintf` to convert values into string, for example DO NOT:
+
+```go
+m := make(map[string]string)
+m["a"] = "b"
+log.Infon("starting", logger.NewIntField("map", fmt.Sprintf("%v", m)))
+```
+
+**ABSOLUTELY NO REFLECTION**: Never use `fmt.Sprintf`, `fmt.Printf`, or any other reflection-based formatting in logging calls. Instead:
+- For string slices: use `strings.Join(slice, ", ")`
+- For custom types: implement a `String() string` method that manually builds the output
+- For primitive types: use appropriate `logger.NewXXXField` constructors directly
+- For complex data: break down into individual fields or implement custom string methods
+- Never use `logger.NewField` since it takes `any`
+
+#### Error Logging
+
+`obskit.Error` MUST BE USED when logging errors:
+
+```go
+log.Errorn("operation failed", obskit.Error(err))
+```
+
+**For code in the /warehouse folder:**
+- Use fields from the `github.com/rudderlabs/rudder-server/warehouse/logfield` package when available
+  (e.g. `logfield.SourceID`, `logfield.TableName`) instead of the rudder-observability-kit fields unless it is an error
+  then you must use `obskit.Error(err)`
+- Use `logfield.Query` if in the code we're logging queries e.g. `sqlStatement`
+- For errors, always use `obskit.Error(err)`
+
+Examples:
+
+```go
+// In warehouse folder
+log.Infon("processing table",
+    logger.NewStringField(logfield.SourceID, sourceID),
+    logger.NewStringField(logfield.TableName, tableName),
+)
+
+// Outside warehouse folder
+log.Infon("processing source",
+    obskit.SourceID(sourceID),
+    logger.NewStringField("tableName", tableName),
+)
+```
+
+#### Migrating Existing Logging Code
+
+When converting existing sugared logging calls to non-sugared methods:
+
+- **ONLY** change the method calls (e.g., `Infof` → `Infon`, `Warnw` → `Warnn`)
+- **PRESERVE** existing message formats, prefixes, and casing
+- **CONVERT** parameters to proper field constructors following the field selection guidelines above
+- **DO NOT** modify message content unless explicitly requested
+
+Example migration:
+```go
+// Before
+log.Infof("AZ: Creating table for destination %s: %v", destID, query)
+
+// After
+log.Infon("AZ: Creating table for destination",
+    logger.NewStringField(logfield.DestinationID, destID),
+    logger.NewStringField(logfield.Query, query),
+)
+```
+
+### Config
+
+Always use rudder-go-kit for configuration.
+
+import `github.com/rudderlabs/rudder-go-kit/config`
+
+#### Init Config
+
+Only init config once in program's main file. Use DI in all other places. DO NOT use global / singleton config pattern.
+
+You should use a service name prefix:
+
+```go
+import (
+	kitconfig "github.com/rudderlabs/rudder-go-kit/config"
+)
+
+conf := kitconfig.New(kitconfig.WithEnvPrefix("SERVICE_NAME"))
+```
+
+#### Getting Values
+
+Always provide default values:
+
+```go
+port := conf.GetInt("HTTP.Port", 8080)
+timeout := conf.GetDuration("HTTP.ShutdownTimeout", 10, time.Second)
+enabled := conf.GetBool("Feature.Enabled", false)
+name := conf.GetString("Service.Name", "default-service")
+```
+
+#### Config during testing
+
+On your test, create a new conf, so you can manipulate it without side-effects.
+
+Only use `Set()` in tests:
+
+```go
+// In tests only
+conf.Set("HTTP.Port", port)
+conf.Set("Profiler.Enabled", false)
+```
+
+### Stats
+
+Always use rudder-go-kit for metrics and statistics.
+
+```go
+import (
+    "github.com/rudderlabs/rudder-go-kit/stats"
+    "github.com/rudderlabs/rudder-go-kit/stats/metric"
+)
+```
+
+#### Stats Init
+
+Always configure stats with service information:
+
+```go
+stat := stats.NewStats(conf, logFactory, svcMetric.NewManager(), []stats.Option{
+    stats.WithServiceName(serviceName),
+    stats.WithServiceVersion(version),
+    stats.WithDefaultHistogramBuckets(customBuckets),
+})
+```
+
+```go
+if err := stat.Start(ctx, stats.DefaultGoRoutineFactory); err != nil {
+    log.Errorn("Failed to start Stats", obskit.Error(err))
+    return err
+}
+defer stat.Stop()
+```
+
+Only init in program's main. Use DI in all other places
+
+#### Usage
+
+TODO
+
+## Context
+
+### Function Signatures
+
+Always pass context as first parameter:
+
+```go
+func runWith(ctx context.Context, conf *kitconfig.Config, log logger.Logger) error {
+    // function body
+}
+```
+
+### Cancellation
+
+Always handle context cancellation properly:
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+```
+
+## Testing
+
+### Test Structure
+
+Always use testify/require for assertions:
+
+```go
+import "github.com/stretchr/testify/require"
+
+func TestSomething(t *testing.T) {
+    require.NoError(t, err, "descriptive error message")
+    require.Equal(t, expected, actual, "descriptive error message")
+}
+```
+
+#### Async Testing
+
+Always use `require.Eventually` for async operations:
+
+```go
+require.Eventually(t, func() bool {
+    // condition to check
+    return someCondition
+}, 10*time.Second, 100*time.Millisecond, "descriptive timeout message")
+```
+
+Avoid using other `require` functions inside `Eventually` and `Never`. The lambda function invoked by `Eventually` and
+`Never` should just return a `bool` and must not make other assertions via `require` or via `t`.
+
+## Error Handling
+
+### Never Ignore Errors
+
+Always handle errors appropriately:
+
+DO NOT:
+
+```go
+result, _ := someFunction()
+```
+
+ALWAYS DO:
+
+```go
+result, err := someFunction()
+if err != nil {
+    // handle error here
+}
+```
+
+### Error Wrapping
+
+In case you can not handle the error and you need to propagate it. You SHOULD consider wrapping it using
+`fmt.Errorf("...: %w)`, if additional context would make it easier for understanding the error.
+
+Avoid using "failure", or "error", or similar word when wrapping. Instead focus on describing the behaviour tha cause the issue.
+
+DO NOT:
+
+```go
+if err != nil {
+    return fmt.Errorf("failed to start server on port %d: %w", port, err)
+}
+```
+
+DO:
+
+```go
+if err != nil {
+    return fmt.Errorf("starting server on port %d: %w", port, err)
+}
+```

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,31 @@
+---
+name: code-reviewer
+description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability. 
+  Use immediately after writing or modifying code.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a senior code reviewer ensuring high standards of code quality and security.
+
+When invoked:
+1. Run git diff to see recent changes
+2. Focus on modified files
+3. Begin review immediately
+
+Review checklist:
+- Code is simple and readable
+- Functions and variables are well-named
+- No duplicated code
+- Proper error handling
+- No exposed secrets or API keys
+- Input validation implemented
+- Good test coverage
+- Performance considerations addressed
+- The project guidelines must be followed (see [CLAUDE.md](./../../CLAUDE.md))
+
+Provide feedback organized by priority:
+- Critical issues (must fix)
+- Warnings (should fix)
+- Suggestions (consider improving)
+
+Include specific examples of how to fix issues.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,7 @@
+---
+name: test-runner
+description: Use proactively to run tests and fix failures
+---
+
+You are a test automation expert. When you see code changes, proactively run the appropriate tests. If tests fail, 
+analyze the failures and fix them while preserving the original test intent.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "Bash(make test:*)",
+      "Bash(go vet:*)",
+      "Bash(go run:*)",
+      "Bash(go test:*)",
+      "Bash(gofmt:*)",
+      "Bash(git tag:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(go run:*)",
       "Bash(go test:*)",
       "Bash(gofmt:*)",
-      "Bash(git tag:*)"
+      "Bash(git tag:*)",
+      "Bash(go tool cover:*)"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+./.ai-agent/guidelines.md

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -165,6 +165,8 @@ func watchFile(file string, conf *conf, stop chan os.Signal) {
 		return
 	}
 
+	log.Debugn("Watching file for changes")
+
 	for {
 		select {
 		case <-stop:

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -122,6 +122,10 @@ func SetWithConfig(c *config.Config, opts ...Option) {
 	if data, err := os.ReadFile(requestsFile); err == nil && len(data) > 0 {
 		fileMode = true
 		requests = strings.TrimSpace(string(data)) + "m"
+		conf.logger.Infon("Using CPU requests from file",
+			logger.NewStringField("requests", requests),
+			logger.NewStringField("file", requestsFile),
+		)
 	}
 
 	Set(requests,

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -57,6 +57,10 @@ func WithRoundQuotaFunc(roundQuotaFunc func(float64) int) Option {
 	return func(c *conf) { c.roundQuotaFunc = roundQuotaFunc }
 }
 
+func WithStopFileWatcher(stop chan os.Signal) Option {
+	return func(c *conf) { c.stop = stop }
+}
+
 func Set(raw string, opts ...Option) {
 	conf := &conf{
 		logger:                logger.NOP,
@@ -167,6 +171,7 @@ func watchFile(conf *conf, file string) {
 	}
 
 	log.Debugn("Watching file for changes")
+	defer log.Debugn("Stopped watching file for changes")
 
 	for {
 		select {

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -81,21 +81,27 @@ func set(raw string, opts ...option) {
 		opt(conf)
 	}
 
-	cpuRequests := 1.0
+	cpuRequests := 0.0
 	if strings.HasSuffix(raw, "m") {
 		value, err := strconv.Atoi(strings.TrimSuffix(raw, "m"))
 		if err == nil {
 			cpuRequests = float64(value) / 1000
 		} else {
-			conf.logger.Warnn("unable to parse CPU requests with Atoi, using default value")
+			conf.logger.Warnn("unable to parse CPU requests with Atoi")
 		}
 	} else {
 		value, err := strconv.ParseFloat(raw, 64)
 		if err == nil {
 			cpuRequests = value
 		} else {
-			conf.logger.Warnn("unable to parse CPU requests with ParseFloat, using default value")
+			conf.logger.Warnn("unable to parse CPU requests with ParseFloat")
 		}
+	}
+
+	// Guard: if no valid configuration provided, don't touch GOMAXPROCS
+	if cpuRequests <= 0 {
+		conf.logger.Warnn("No valid CPU requests configuration provided, GOMAXPROCS will not be modified")
+		return
 	}
 
 	// Calculate GOMAXPROCS

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -145,7 +145,7 @@ func SetWithConfig(c *config.Config, opts ...Option) {
 		conf.logger.Infon("Starting file watcher to monitor CPU requests changes",
 			logger.NewStringField("file", requestsFile),
 		)
-		signal.Notify(conf.stop, os.Kill, os.Interrupt, syscall.SIGTERM)
+		signal.Notify(conf.stop, os.Interrupt, syscall.SIGTERM)
 		go watchFile(conf, requestsFile)
 	}
 }

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -20,7 +20,7 @@ func TestSet_Default(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)  // Capture original value
 	defer runtime.GOMAXPROCS(before) // Restore after test
 
-	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 2)
+	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 0, 2)
 	Set("1100m", WithLogger(mockLog))
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1100m * 1.5 = 1.65 → ceil = 2
 }
@@ -32,7 +32,7 @@ func TestSetWithConfig_Default(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 2)
+	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 12, 2)
 	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1100m * 1.5 = 1.65 → ceil = 2
@@ -42,16 +42,8 @@ func TestSet_WithInvalidCPURequest_Invalid1(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	ctrl := gomock.NewController(t)
-	mockLog := mock_logger.NewMockLogger(ctrl)
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 0, 2)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
-	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
-		logger.NewFloatField("cpuRequests", 1),
-		logger.NewFloatField("multiplier", 1.5),
-		logger.NewIntField("minProcs", 1),
-		logger.NewIntField("result", 2),
-		logger.NewIntField("GOMAXPROCS", 2),
-	).Times(1)
 
 	Set("invalid", WithLogger(mockLog))
 
@@ -65,16 +57,8 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid1(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	ctrl := gomock.NewController(t)
-	mockLog := mock_logger.NewMockLogger(ctrl)
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
-	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
-		logger.NewFloatField("cpuRequests", 1),
-		logger.NewFloatField("multiplier", 1.5),
-		logger.NewIntField("minProcs", 1),
-		logger.NewIntField("result", 2),
-		logger.NewIntField("GOMAXPROCS", 2),
-	).Times(1)
 
 	SetWithConfig(cfg, WithLogger(mockLog))
 
@@ -85,16 +69,8 @@ func TestSet_WithInvalidCPURequest_Invalid2(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	ctrl := gomock.NewController(t)
-	mockLog := mock_logger.NewMockLogger(ctrl)
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 0, 2)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
-	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
-		logger.NewFloatField("cpuRequests", 1),
-		logger.NewFloatField("multiplier", 1.5),
-		logger.NewIntField("minProcs", 1),
-		logger.NewIntField("result", 2),
-		logger.NewIntField("GOMAXPROCS", 2),
-	).Times(1)
 
 	Set("invalid_m", WithLogger(mockLog))
 
@@ -108,16 +84,8 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid2(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	ctrl := gomock.NewController(t)
-	mockLog := mock_logger.NewMockLogger(ctrl)
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
-	mockLog.EXPECT().Infon("GOMAXPROCS has been configured",
-		logger.NewFloatField("cpuRequests", 1),
-		logger.NewFloatField("multiplier", 1.5),
-		logger.NewIntField("minProcs", 1),
-		logger.NewIntField("result", 2),
-		logger.NewIntField("GOMAXPROCS", 2),
-	).Times(1)
 
 	SetWithConfig(cfg, WithLogger(mockLog))
 
@@ -128,7 +96,7 @@ func TestSet_WithMinProcs(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 0.1, 5, 1.5, 5)
+	mockLog := requireLoggerInfo(t, 0.1, 5, 1.5, 0, 5)
 	Set("100m",
 		WithMinProcs(5),
 		WithLogger(mockLog),
@@ -145,7 +113,7 @@ func TestSetWithConfig_WithMinProcs(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 0.1, 5, 1.5, 5)
+	mockLog := requireLoggerInfo(t, 0.1, 5, 1.5, 12, 5)
 	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 5, runtime.GOMAXPROCS(0)) // MinProcs overrides calculated value
@@ -155,7 +123,7 @@ func TestSet_WithMultiplier(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 2)
+	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 0, 2)
 	Set("300m",
 		WithCPURequestsMultiplier(4),
 		WithLogger(mockLog),
@@ -172,7 +140,7 @@ func TestSetWithConfig_WithMultiplier(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 2)
+	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 12, 2)
 	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 300m * 4 = 1.2 → ceil = 2
@@ -184,13 +152,67 @@ func TestSet_CustomRoundQuotaFunc(t *testing.T) {
 
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
-	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 2)
+	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 0, 2)
 	Set("1500m",
 		WithRoundQuotaFunc(roundFloor),
 		WithLogger(mockLog),
 	)
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1500m * 1.5 = 2.25 → floor = 2
+}
+
+func TestSet_WithMaxProcs(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	mockLog := requireLoggerInfo(t, 10, 1, 1.5, 8, 8)
+	Set("10000m",
+		WithMaxProcs(8),
+		WithLogger(mockLog),
+	)
+
+	require.Equal(t, 8, runtime.GOMAXPROCS(0)) // 10000m * 1.5 = 15 → capped at 8
+}
+
+func TestSet_WithMaxProcsNoEffect(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	mockLog := requireLoggerInfo(t, 0.1, 1, 1.5, 10, 1)
+	Set("100m",
+		WithMaxProcs(10),
+		WithLogger(mockLog),
+	)
+
+	require.Equal(t, 1, runtime.GOMAXPROCS(0)) // 100m * 1.5 = 0.15 → ceil = 1, max has no effect
+}
+
+func TestSetWithConfig_WithMaxProcs(t *testing.T) {
+	cfg := config.New()
+	cfg.Set("Requests", "10000m")
+	cfg.Set("MaxProcs", 8)
+
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	mockLog := requireLoggerInfo(t, 10, 1, 1.5, 8, 8)
+	SetWithConfig(cfg, WithLogger(mockLog))
+
+	require.Equal(t, 8, runtime.GOMAXPROCS(0)) // 10000m * 1.5 = 15 → capped at 8
+}
+
+func TestSetWithConfig_WithMaxProcsNoEffect(t *testing.T) {
+	cfg := config.New()
+	cfg.Set("Requests", "100m")
+	cfg.Set("MaxProcs", 10)
+
+	before := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(before)
+
+	mockLog := requireLoggerInfo(t, 0.1, 1, 1.5, 10, 1)
+	SetWithConfig(cfg, WithLogger(mockLog))
+
+	require.Equal(t, 1, runtime.GOMAXPROCS(0)) // 100m * 1.5 = 0.15 → ceil = 1, max has no effect
 }
 
 func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
@@ -202,7 +224,7 @@ func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
 
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
-	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 2)
+	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 12, 2)
 	SetWithConfig(cfg,
 		WithRoundQuotaFunc(roundFloor),
 		WithLogger(mockLog),
@@ -242,7 +264,7 @@ func TestSetWithConfig_ReadFromFile(t *testing.T) {
 	cfg.Set("RequestsFile", requestsFile)
 	cfg.Set("Watch", false)
 
-	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 3)
+	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 12, 3)
 	mockLog.EXPECT().Infon("Using CPU requests from file",
 		logger.NewStringField("requests", "1500m"),
 		logger.NewStringField("file", requestsFile),
@@ -266,7 +288,7 @@ func TestSetWithConfig_EmptyFile(t *testing.T) {
 	cfg.Set("RequestsFile", requestsFile)
 	cfg.Set("Watch", false)
 
-	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 2)
+	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 12, 2)
 	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Falls back to Requests config: 1100m * 1.5 = 1.65 → ceil = 2
@@ -281,7 +303,7 @@ func TestSetWithConfig_NonExistentFile(t *testing.T) {
 	cfg.Set("RequestsFile", "/non/existent/file")
 	cfg.Set("Watch", false)
 
-	mockLog := requireLoggerInfo(t, 2.0, 1, 1.5, 3)
+	mockLog := requireLoggerInfo(t, 2.0, 1, 1.5, 12, 3)
 	SetWithConfig(cfg, WithLogger(mockLog))
 
 	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Falls back to Requests config: 2000m * 1.5 = 3.0 → ceil = 3
@@ -299,7 +321,7 @@ func TestSetWithConfig_WatchDisabled(t *testing.T) {
 	cfg.Set("RequestsFile", requestsFile)
 	cfg.Set("Watch", false)
 
-	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 2)
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
 	mockLog.EXPECT().Infon("Using CPU requests from file",
 		logger.NewStringField("requests", "1000m"),
 		logger.NewStringField("file", requestsFile),
@@ -323,7 +345,7 @@ func TestSetWithConfig_FileWatcherWithChanges(t *testing.T) {
 	cfg.Set("RequestsFile", requestsFile)
 	cfg.Set("Watch", true)
 
-	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 2)
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
 	mockLog.EXPECT().Infon("Using CPU requests from file",
 		logger.NewStringField("requests", "1000m"),
 		logger.NewStringField("file", requestsFile),
@@ -336,6 +358,7 @@ func TestSetWithConfig_FileWatcherWithChanges(t *testing.T) {
 		logger.NewFloatField("cpuRequests", 2),
 		logger.NewFloatField("multiplier", 1.5),
 		logger.NewIntField("minProcs", 1),
+		logger.NewIntField("maxProcs", 12),
 		logger.NewIntField("result", 3),
 		logger.NewIntField("GOMAXPROCS", 3),
 	).MinTimes(1)
@@ -375,7 +398,7 @@ func TestSetWithConfig_FileWatcherWithSignal(t *testing.T) {
 
 	stop := make(chan os.Signal, 1)
 
-	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 2)
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
 	mockLog.EXPECT().Infon("Using CPU requests from file",
 		logger.NewStringField("requests", "1000m"),
 		logger.NewStringField("file", requestsFile),
@@ -422,6 +445,7 @@ func requireLoggerInfo(t testing.TB,
 	cpuRequests float64,
 	minProcs int64,
 	multiplier float64,
+	maxProcs int64,
 	result int64,
 ) *mock_logger.MockLogger {
 	t.Helper()
@@ -431,6 +455,7 @@ func requireLoggerInfo(t testing.TB,
 		logger.NewFloatField("cpuRequests", cpuRequests),
 		logger.NewFloatField("multiplier", multiplier),
 		logger.NewIntField("minProcs", minProcs),
+		logger.NewIntField("maxProcs", maxProcs),
 		logger.NewIntField("result", result),
 		logger.NewIntField("GOMAXPROCS", result),
 	).Times(1)

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -21,7 +21,7 @@ func TestSet_Default(t *testing.T) {
 	defer runtime.GOMAXPROCS(before) // Restore after test
 
 	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 0, 2)
-	Set("1100m", WithLogger(mockLog))
+	set("1100m", withLogger(mockLog))
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1100m * 1.5 = 1.65 → ceil = 2
 }
 
@@ -32,8 +32,9 @@ func TestSetWithConfig_Default(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 12, 2)
-	SetWithConfig(cfg, WithLogger(mockLog))
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, int64(numCPU), 2)
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1100m * 1.5 = 1.65 → ceil = 2
 }
@@ -45,7 +46,7 @@ func TestSet_WithInvalidCPURequest_Invalid1(t *testing.T) {
 	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 0, 2)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
 
-	Set("invalid", WithLogger(mockLog))
+	set("invalid", withLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Defaults to 1 * 1.5 → ceil = 2
 }
@@ -57,10 +58,11 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid1(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, int64(numCPU), 2)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with ParseFloat, using default value").Times(1)
 
-	SetWithConfig(cfg, WithLogger(mockLog))
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Defaults to 1 * 1.5 → ceil = 2
 }
@@ -72,7 +74,7 @@ func TestSet_WithInvalidCPURequest_Invalid2(t *testing.T) {
 	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 0, 2)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
 
-	Set("invalid_m", WithLogger(mockLog))
+	set("invalid_m", withLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Defaults to 1 * 1.5 → ceil = 2
 }
@@ -84,10 +86,11 @@ func TestSetWithConfig_WithInvalidCPURequest_Invalid2(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, int64(numCPU), 2)
 	mockLog.EXPECT().Warnn("unable to parse CPU requests with Atoi, using default value").Times(1)
 
-	SetWithConfig(cfg, WithLogger(mockLog))
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Defaults to 1 * 1.5 → ceil = 2
 }
@@ -97,9 +100,9 @@ func TestSet_WithMinProcs(t *testing.T) {
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 0.1, 5, 1.5, 0, 5)
-	Set("100m",
-		WithMinProcs(5),
-		WithLogger(mockLog),
+	set("100m",
+		withMinProcs(5),
+		withLogger(mockLog),
 	)
 
 	require.Equal(t, 5, runtime.GOMAXPROCS(0)) // MinProcs overrides calculated value
@@ -113,8 +116,9 @@ func TestSetWithConfig_WithMinProcs(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 0.1, 5, 1.5, 12, 5)
-	SetWithConfig(cfg, WithLogger(mockLog))
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 0.1, 5, 1.5, int64(numCPU), 5)
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 5, runtime.GOMAXPROCS(0)) // MinProcs overrides calculated value
 }
@@ -124,9 +128,9 @@ func TestSet_WithMultiplier(t *testing.T) {
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 0, 2)
-	Set("300m",
-		WithCPURequestsMultiplier(4),
-		WithLogger(mockLog),
+	set("300m",
+		withCPURequestsMultiplier(4),
+		withLogger(mockLog),
 	)
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 300m * 4 = 1.2 → ceil = 2
@@ -140,8 +144,9 @@ func TestSetWithConfig_WithMultiplier(t *testing.T) {
 	before := runtime.GOMAXPROCS(0)
 	defer runtime.GOMAXPROCS(before)
 
-	mockLog := requireLoggerInfo(t, 0.3, 1, 4, 12, 2)
-	SetWithConfig(cfg, WithLogger(mockLog))
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 0.3, 1, 4, int64(numCPU), 2)
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 300m * 4 = 1.2 → ceil = 2
 }
@@ -153,9 +158,9 @@ func TestSet_CustomRoundQuotaFunc(t *testing.T) {
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
 	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 0, 2)
-	Set("1500m",
-		WithRoundQuotaFunc(roundFloor),
-		WithLogger(mockLog),
+	set("1500m",
+		withRoundQuotaFunc(roundFloor),
+		withLogger(mockLog),
 	)
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1500m * 1.5 = 2.25 → floor = 2
@@ -166,9 +171,9 @@ func TestSet_WithMaxProcs(t *testing.T) {
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 10, 1, 1.5, 8, 8)
-	Set("10000m",
-		WithMaxProcs(8),
-		WithLogger(mockLog),
+	set("10000m",
+		withMaxProcs(8),
+		withLogger(mockLog),
 	)
 
 	require.Equal(t, 8, runtime.GOMAXPROCS(0)) // 10000m * 1.5 = 15 → capped at 8
@@ -179,9 +184,9 @@ func TestSet_WithMaxProcsNoEffect(t *testing.T) {
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 0.1, 1, 1.5, 10, 1)
-	Set("100m",
-		WithMaxProcs(10),
-		WithLogger(mockLog),
+	set("100m",
+		withMaxProcs(10),
+		withLogger(mockLog),
 	)
 
 	require.Equal(t, 1, runtime.GOMAXPROCS(0)) // 100m * 1.5 = 0.15 → ceil = 1, max has no effect
@@ -196,7 +201,7 @@ func TestSetWithConfig_WithMaxProcs(t *testing.T) {
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 10, 1, 1.5, 8, 8)
-	SetWithConfig(cfg, WithLogger(mockLog))
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 8, runtime.GOMAXPROCS(0)) // 10000m * 1.5 = 15 → capped at 8
 }
@@ -210,7 +215,7 @@ func TestSetWithConfig_WithMaxProcsNoEffect(t *testing.T) {
 	defer runtime.GOMAXPROCS(before)
 
 	mockLog := requireLoggerInfo(t, 0.1, 1, 1.5, 10, 1)
-	SetWithConfig(cfg, WithLogger(mockLog))
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 1, runtime.GOMAXPROCS(0)) // 100m * 1.5 = 0.15 → ceil = 1, max has no effect
 }
@@ -224,10 +229,11 @@ func TestSetWithConfig_CustomRoundQuotaFunc(t *testing.T) {
 
 	roundFloor := func(f float64) int { return int(math.Floor(f)) }
 
-	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 12, 2)
-	SetWithConfig(cfg,
-		WithRoundQuotaFunc(roundFloor),
-		WithLogger(mockLog),
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, int64(numCPU), 2)
+	setWithConfig(cfg,
+		withRoundQuotaFunc(roundFloor),
+		withLogger(mockLog),
 	)
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1500m * 1.5 = 2.25 → floor = 2
@@ -264,13 +270,14 @@ func TestSetWithConfig_ReadFromFile(t *testing.T) {
 	cfg.Set("RequestsFile", requestsFile)
 	cfg.Set("Watch", false)
 
-	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, 12, 3)
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 1.5, 1, 1.5, int64(numCPU), 3)
 	mockLog.EXPECT().Infon("Using CPU requests from file",
 		logger.NewStringField("requests", "1500m"),
 		logger.NewStringField("file", requestsFile),
 	).Times(1)
 
-	SetWithConfig(cfg, WithLogger(mockLog))
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // 1500m * 1.5 = 2.25 → ceil = 3
 }
@@ -288,8 +295,9 @@ func TestSetWithConfig_EmptyFile(t *testing.T) {
 	cfg.Set("RequestsFile", requestsFile)
 	cfg.Set("Watch", false)
 
-	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, 12, 2)
-	SetWithConfig(cfg, WithLogger(mockLog))
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 1.1, 1, 1.5, int64(numCPU), 2)
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // Falls back to Requests config: 1100m * 1.5 = 1.65 → ceil = 2
 }
@@ -303,8 +311,9 @@ func TestSetWithConfig_NonExistentFile(t *testing.T) {
 	cfg.Set("RequestsFile", "/non/existent/file")
 	cfg.Set("Watch", false)
 
-	mockLog := requireLoggerInfo(t, 2.0, 1, 1.5, 12, 3)
-	SetWithConfig(cfg, WithLogger(mockLog))
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 2.0, 1, 1.5, int64(numCPU), 3)
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 3, runtime.GOMAXPROCS(0)) // Falls back to Requests config: 2000m * 1.5 = 3.0 → ceil = 3
 }
@@ -321,14 +330,15 @@ func TestSetWithConfig_WatchDisabled(t *testing.T) {
 	cfg.Set("RequestsFile", requestsFile)
 	cfg.Set("Watch", false)
 
-	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, int64(numCPU), 2)
 	mockLog.EXPECT().Infon("Using CPU requests from file",
 		logger.NewStringField("requests", "1000m"),
 		logger.NewStringField("file", requestsFile),
 	).Times(1)
 	mockLog.EXPECT().Infon("Starting file watcher to monitor CPU requests changes", gomock.Any()).Times(0)
 
-	SetWithConfig(cfg, WithLogger(mockLog))
+	setWithConfig(cfg, withLogger(mockLog))
 
 	require.Equal(t, 2, runtime.GOMAXPROCS(0)) // 1000m * 1.5 = 1.5 → ceil = 2
 }
@@ -345,7 +355,8 @@ func TestSetWithConfig_FileWatcherWithChanges(t *testing.T) {
 	cfg.Set("RequestsFile", requestsFile)
 	cfg.Set("Watch", true)
 
-	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, int64(numCPU), 2)
 	mockLog.EXPECT().Infon("Using CPU requests from file",
 		logger.NewStringField("requests", "1000m"),
 		logger.NewStringField("file", requestsFile),
@@ -358,7 +369,7 @@ func TestSetWithConfig_FileWatcherWithChanges(t *testing.T) {
 		logger.NewFloatField("cpuRequests", 2),
 		logger.NewFloatField("multiplier", 1.5),
 		logger.NewIntField("minProcs", 1),
-		logger.NewIntField("maxProcs", 12),
+		logger.NewIntField("maxProcs", int64(numCPU)),
 		logger.NewIntField("result", 3),
 		logger.NewIntField("GOMAXPROCS", 3),
 	).MinTimes(1)
@@ -368,7 +379,7 @@ func TestSetWithConfig_FileWatcherWithChanges(t *testing.T) {
 		close(watcherIsSetup)
 	}).Times(1)
 
-	SetWithConfig(cfg, WithLogger(mockLog))
+	setWithConfig(cfg, withLogger(mockLog))
 	initialProcs := runtime.GOMAXPROCS(0)
 	require.Equal(t, 2, initialProcs) // 1000m * 1.5 = 1.5 → ceil = 2
 
@@ -398,7 +409,8 @@ func TestSetWithConfig_FileWatcherWithSignal(t *testing.T) {
 
 	stop := make(chan os.Signal, 1)
 
-	mockLog := requireLoggerInfo(t, 1, 1, 1.5, 12, 2)
+	numCPU := runtime.NumCPU()
+	mockLog := requireLoggerInfo(t, 1, 1, 1.5, int64(numCPU), 2)
 	mockLog.EXPECT().Infon("Using CPU requests from file",
 		logger.NewStringField("requests", "1000m"),
 		logger.NewStringField("file", requestsFile),
@@ -419,7 +431,7 @@ func TestSetWithConfig_FileWatcherWithSignal(t *testing.T) {
 		close(watcherStopped)
 	}).Times(1)
 
-	SetWithConfig(cfg, WithLogger(mockLog), WithStopFileWatcher(stop))
+	setWithConfig(cfg, withLogger(mockLog), withStopFileWatcher(stop))
 
 	// Wait for watcher to be setup
 	select {


### PR DESCRIPTION
# Description

At the moment the `maxprocs` doesn't support VPA in-place.

In this PR I'm addressing this, using a file watcher. We would then need to configure our pods on K8s as such:

```yaml
      volumeMounts:
        - name: podinfo
          mountPath: /etc/podinfo
  volumes:
    - name: podinfo
      downwardAPI:
        items:
          - path: "cpu_request"
            resourceFieldRef:
              containerName: client-container
              resource: requests.cpu
              divisor: 1m
```

### Additional changes

I added the usual AI guidelines to this repo as well.

## Linear Ticket

< Fixes [PIPE-2451](https://linear.app/rudderstack/issue/PIPE-2451/go-kit-maxprocs-to-support-vpa-in-place) >

## Slack thread

https://rudderlabs.slack.com/archives/C02AASYS6R1/p1758803093901929

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
