### PR TITLE
feat: attempt-aware retryablehttp strategy

### DIFF
--- a/retryablehttp/retryablehttp.go
+++ b/retryablehttp/retryablehttp.go
@@ -17,11 +17,12 @@ type HttpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// retryStrategy is a function that determines whether to retry based on the response and error.
+// retryStrategy is a function that determines whether to retry based on the attempt number, response and error.
+// attempt is the number of the request that just completed (1 = initial request, 2 = first retry, ...).
 // It should return true if the request should be retried, along with an error for the reason of retry.
 // If it returns false, it means no retry is needed and the error(if any while making http req) along with a response can be returned directly.
 // if retry is true, it means the request should be retried and error(if any from retryStrategy) will be sent to onFailure.
-type retryStrategy func(resp *http.Response, err error) (bool, error)
+type retryStrategy func(attempt int, resp *http.Response, err error) (bool, error)
 
 type Config struct {
 	// MaxRetry is the maximum number of retries (<0 means no limit).
@@ -144,14 +145,16 @@ func (c *retryableHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if c.config.MaxRetry >= 0 {
 		maxTries = uint(c.config.MaxRetry) + 1
 	}
+	var attempt int
 	_, _ = backoff.Retry(req.Context(),
 		func() (*http.Response, error) {
 			// if the body was read, we need to reset it
 			if bodyBytes != nil {
 				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 			}
+			attempt++
 			resp, err = c.HttpClient.Do(req) // nolint: bodyclose
-			if retry, retryErr := c.shouldRetry(resp, err); retry {
+			if retry, retryErr := c.shouldRetry(attempt, resp, err); retry {
 				return nil, fmt.Errorf("retryable error: %w", retryErr)
 			}
 			return resp, nil
@@ -175,7 +178,7 @@ func (c *retryableHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func BaseRetryStrategy(resp *http.Response, err error) (bool, error) {
+func BaseRetryStrategy(_ int, resp *http.Response, err error) (bool, error) {
 	if err != nil {
 		return true, err
 	}

--- a/retryablehttp/retryablehttp_test.go
+++ b/retryablehttp/retryablehttp_test.go
@@ -316,7 +316,7 @@ func TestRetryableHTTPClient_WithCustomRetryStrategy(t *testing.T) {
 
 	// create a custom retry strategy that retries on 404s (which normally wouldn't retry)
 	customRetryCount := 0
-	customRetryStrategy := func(resp *http.Response, err error) (bool, error) {
+	customRetryStrategy := func(_ int, resp *http.Response, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -371,7 +371,9 @@ func TestRetryableHTTPClient_WithCustomRetryStrategy(t *testing.T) {
 func TestRetryableHTTPClient_WithCustomRetryStrategyHttpClientReturnError(t *testing.T) {
 	// create a custom retry strategy that retries on 404s (which normally wouldn't retry)
 	customRetryCount := 0
-	customRetryStrategy := func(resp *http.Response, err error) (bool, error) {
+	var observedAttempts []int
+	customRetryStrategy := func(attempt int, resp *http.Response, err error) (bool, error) {
+		observedAttempts = append(observedAttempts, attempt)
 		customRetryCount++
 		if customRetryCount < 3 {
 			return true, fmt.Errorf("custom retry strategy: retrying")
@@ -409,8 +411,9 @@ func TestRetryableHTTPClient_WithCustomRetryStrategyHttpClientReturnError(t *tes
 	// Assertions
 	require.Error(t, err)
 	require.Nil(t, resp)
-	require.Equal(t, 2, failureCalls)     // Should be called for each retry
-	require.Equal(t, 3, customRetryCount) // Our strategy should have been called and incremented
+	require.Equal(t, 2, failureCalls)                  // Should be called for each retry
+	require.Equal(t, 3, customRetryCount)              // Our strategy should have been called and incremented
+	require.Equal(t, []int{1, 2, 3}, observedAttempts) // Attempt should be 1-indexed and incremented per call
 
 	if resp != nil {
 		resp.Body.Close()


### PR DESCRIPTION
# Description

Adds an `attempt int` parameter to the `retryStrategy` callback used by `retryablehttp.NewRetryableHTTPClient`, so custom strategies can make attempt-aware decisions (e.g. emit metrics tagged by attempt number, log differently on later retries, etc.).

Changes:
- `retryStrategy` signature changes from `func(resp, err) (bool, error)` to `func(attempt int, resp, err) (bool, error)`. `attempt` is 1-indexed: `1` is the initial request, `2` is the first retry, and so on.
- `BaseRetryStrategy` updated to accept (and ignore) the new parameter.
- The retryable client increments `attempt` before each call so the strategy sees the number of the request that just completed.
- Tests updated; new assertion verifies attempts are passed as `[1, 2, 3]` across retries.

This is a breaking change for callers using `WithCustomRetryStrategy`, but the only known consumer (rudder-server transformer client) is being updated in https://github.com/rudderlabs/rudder-server/pull/6914 to use the new signature.

## Linear Ticket

N/A

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.