### PR TITLE
chore(ci): workflow cleanup (SEC-284)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
+          cache: false
       - run: go version
       - run: go mod download # Not required, used to segregate module download vs test times
       - name: Run tests
@@ -90,6 +91,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
+          cache: false
       - run: go version
       - run: go mod download
       - name: Test package [ ${{ matrix.package }} ]


### PR DESCRIPTION
Disables implicit Go module cache restore on setup-go in this workflow. No behavioral change to tests; cache restore is removed from a privileged job.

Linear: SEC-284