### PR TITLE
chore: gubernator docker helper

### DIFF
--- a/testhelper/docker/resource/gubernator/config.go
+++ b/testhelper/docker/resource/gubernator/config.go
@@ -1,0 +1,27 @@
+package gubernator
+
+import (
+	"github.com/ory/dockertest/v3/docker"
+)
+
+type Option func(*config)
+
+// WithTag overrides the default gubernator image tag.
+func WithTag(tag string) Option {
+	return func(c *config) {
+		c.tag = tag
+	}
+}
+
+// WithNetwork attaches the container to the given docker network so that it is
+// reachable from other containers in the same network.
+func WithNetwork(network *docker.Network) Option {
+	return func(c *config) {
+		c.network = network
+	}
+}
+
+type config struct {
+	tag     string
+	network *docker.Network
+}

--- a/testhelper/docker/resource/gubernator/gubernator.go
+++ b/testhelper/docker/resource/gubernator/gubernator.go
@@ -1,0 +1,131 @@
+// Package gubernator provides a docker test helper that starts a single-node
+// gubernator (https://github.com/gubernator-io/gubernator) instance suitable
+// for integration tests.
+//
+// gubernator is distributed as a "FROM scratch" image (no shell), so readiness
+// is verified with an HTTP GET against the /v1/HealthCheck endpoint from the
+// host rather than by exec-ing into the container.
+//
+// The instance is configured for member-list peer discovery pointing at itself
+// over the loopback interface. This way the single node owns every rate limit
+// key and reports itself as a healthy peer, which is required for GLOBAL
+// behavior requests to be served.
+package gubernator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/ory/dockertest/v3"
+
+	"github.com/rudderlabs/rudder-go-kit/httputil"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/internal"
+	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/registry"
+)
+
+const (
+	grpcPort       = "1051"
+	httpPort       = "1050"
+	defaultVersion = "v2.19.1"
+)
+
+type Resource struct {
+	// GRPCURL is the host:port to use with gubernator.DialV1Server.
+	GRPCURL string
+	// HTTPURL is the base URL (with scheme) of the gubernator HTTP gateway.
+	HTTPURL string
+	// GRPCURLInNetwork is the gRPC address reachable from the provided docker
+	// network (if any).
+	GRPCURLInNetwork string
+
+	purge func()
+}
+
+// Purge can be called to remove the container before the test finishes. Useful
+// to test how the system behaves when gubernator becomes unreachable.
+func (r *Resource) Purge() { r.purge() }
+
+func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource, error) {
+	c := &config{tag: defaultVersion}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	var networkID string
+	if c.network != nil {
+		networkID = c.network.ID
+	}
+
+	container, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository:   registry.ImagePath("ghcr.io/gubernator-io/gubernator"),
+		Tag:          c.tag,
+		ExposedPorts: []string{grpcPort + "/tcp", httpPort + "/tcp"},
+		PortBindings: internal.IPv4PortBindings([]string{grpcPort, httpPort}),
+		Env: []string{
+			"GUBER_GRPC_ADDRESS=0.0.0.0:" + grpcPort,
+			"GUBER_HTTP_ADDRESS=0.0.0.0:" + httpPort,
+			// Advertise and discover ourselves over loopback so the single node forms a one-member cluster and
+			// owns all rate limit keys.
+			"GUBER_ADVERTISE_ADDRESS=127.0.0.1:" + grpcPort,
+			"GUBER_PEER_DISCOVERY_TYPE=member-list",
+			"GUBER_MEMBERLIST_KNOWN_NODES=127.0.0.1:7946",
+		},
+		NetworkID: networkID,
+		Auth:      registry.AuthConfiguration(),
+	}, internal.DefaultHostConfig)
+	if err != nil {
+		return nil, fmt.Errorf("cannot run gubernator container: %w", err)
+	}
+
+	purgeOnce := sync.Once{}
+	purge := func() {
+		purgeOnce.Do(func() {
+			if err := pool.Purge(container); err != nil {
+				d.Log("Could not purge resource:", err)
+			}
+		})
+	}
+	d.Cleanup(purge)
+
+	grpcURL := fmt.Sprintf("127.0.0.1:%s", container.GetPort(grpcPort+"/tcp"))
+	httpURL := fmt.Sprintf("http://127.0.0.1:%s", container.GetPort(httpPort+"/tcp"))
+
+	if err := pool.Retry(func() error {
+		resp, err := http.Get(httpURL + "/v1/HealthCheck")
+		if err != nil {
+			return err
+		}
+		defer func() { httputil.CloseResponse(resp) }()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("gubernator healthcheck status: %s", resp.Status)
+		}
+		var hc struct {
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&hc); err != nil {
+			return fmt.Errorf("decoding gubernator healthcheck: %w", err)
+		}
+		if hc.Status != "healthy" {
+			return fmt.Errorf("gubernator not healthy: %s (%s)", hc.Status, hc.Message)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	var grpcURLInNetwork string
+	if c.network != nil {
+		grpcURLInNetwork = container.GetIPInNetwork(&dockertest.Network{Network: c.network}) + ":" + grpcPort
+	}
+
+	return &Resource{
+		GRPCURL:          grpcURL,
+		HTTPURL:          httpURL,
+		GRPCURLInNetwork: grpcURLInNetwork,
+		purge:            purge,
+	}, nil
+}

--- a/testhelper/docker/resource/gubernator/gubernator.go
+++ b/testhelper/docker/resource/gubernator/gubernator.go
@@ -23,7 +23,6 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/httputil"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource"
 	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/internal"
-	"github.com/rudderlabs/rudder-go-kit/testhelper/docker/resource/registry"
 )
 
 const (
@@ -60,7 +59,10 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource
 	}
 
 	container, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository:   registry.ImagePath("ghcr.io/gubernator-io/gubernator"),
+		// gubernator is only published on ghcr.io, which is not proxied through the DockerHub registry mirror,
+		// so the image is pulled directly (anonymously) without the mirror credentials. Passing the mirror's
+		// auth here would make ghcr.io reject the pull with "denied".
+		Repository:   "ghcr.io/gubernator-io/gubernator",
 		Tag:          c.tag,
 		ExposedPorts: []string{grpcPort + "/tcp", httpPort + "/tcp"},
 		PortBindings: internal.IPv4PortBindings([]string{grpcPort, httpPort}),
@@ -74,7 +76,6 @@ func Setup(pool *dockertest.Pool, d resource.Cleaner, opts ...Option) (*Resource
 			"GUBER_MEMBERLIST_KNOWN_NODES=127.0.0.1:7946",
 		},
 		NetworkID: networkID,
-		Auth:      registry.AuthConfiguration(),
 	}, internal.DefaultHostConfig)
 	if err != nil {
 		return nil, fmt.Errorf("cannot run gubernator container: %w", err)

--- a/testhelper/docker/resource/gubernator/gubernator_test.go
+++ b/testhelper/docker/resource/gubernator/gubernator_test.go
@@ -1,0 +1,68 @@
+package gubernator
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-go-kit/httputil"
+)
+
+// TestGubernator verifies the helper boots a working gubernator instance by exercising the rate limit endpoint
+// over HTTP (so the test stays free of the gubernator Go client dependency).
+// It sends more hits than the configured limit and asserts the instance reports OVER_LIMIT,
+// proving it is both healthy and actually enforcing limits.
+func TestGubernator(t *testing.T) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	res, err := Setup(pool, t)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.GRPCURL)
+	require.NotEmpty(t, res.HTTPURL)
+
+	const limit = 2
+	getRateLimit := func(t *testing.T) string {
+		t.Helper()
+		// "hits" is the cost of the request
+		// "algorithm" is an enum (1=TOKEN_BUCKET, 2=LEAKY_BUCKET)
+		// "behavior" is a bitmask (2=GLOBAL)
+		body := `{
+			"requests": [
+				{
+					"name":"test",
+					"unique_key":"key-1",
+					"hits":1,
+					"limit":2,
+					"duration":1000,
+					"algorithm":1,
+					"behavior":2
+				}
+			]
+		}`
+		resp, err := http.Post(res.HTTPURL+"/v1/GetRateLimits", "application/json", bytes.NewBufferString(body))
+		require.NoError(t, err)
+		defer func() { httputil.CloseResponse(resp) }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var decoded struct {
+			Responses []struct {
+				Status string `json:"status"`
+			} `json:"responses"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&decoded))
+		require.Len(t, decoded.Responses, 1)
+		return decoded.Responses[0].Status
+	}
+
+	// First `limit` requests are under the limit.
+	for range limit {
+		require.Equal(t, "UNDER_LIMIT", getRateLimit(t))
+	}
+	// The next request exceeds the limit.
+	require.Equal(t, "OVER_LIMIT", getRateLimit(t))
+}


### PR DESCRIPTION
# Description

Gubernator Docker helper for integration tests.

## Linear Ticket

< Fixes [PIPE-3156](https://linear.app/rudderstack/issue/PIPE-3156/go-kit-to-add-support-for-integration-tests-that-use-gubernator) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
